### PR TITLE
feat: formalize scripts creations (formerly commands)

### DIFF
--- a/packages/create-testers/src/testPreset.test.ts
+++ b/packages/create-testers/src/testPreset.test.ts
@@ -6,8 +6,8 @@ import { testPreset } from "./testPreset.js";
 
 const emptyCreation = {
 	addons: [],
-	commands: [],
 	files: {},
+	scripts: [],
 };
 
 const base = createBase({

--- a/packages/create/src/internals/executePresetBlocks.ts
+++ b/packages/create/src/internals/executePresetBlocks.ts
@@ -71,8 +71,8 @@ export function executePresetBlocks<OptionsShape extends AnyShape>(
 		(created, next) => mergeCreations(created, next.creation ?? {}),
 		{
 			addons: [],
-			commands: [],
 			files: {},
+			scripts: [],
 		},
 	);
 }

--- a/packages/create/src/mergers/mergeCommands.test.ts
+++ b/packages/create/src/mergers/mergeCommands.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, test } from "vitest";
+
+import { mergeCommands } from "./mergeCommands.js";
+
+describe("mergeCommands", () => {
+	test.each([
+		[undefined, undefined, undefined],
+		[[], undefined, []],
+		[undefined, [], []],
+		[[], [], []],
+		[
+			[
+				{
+					commands: ["pnpm build"],
+					phase: 0,
+				},
+			],
+			undefined,
+			[
+				{
+					commands: ["pnpm build"],
+					phase: 0,
+				},
+			],
+		],
+		[
+			[
+				{
+					commands: ["pnpm build"],
+					phase: 0,
+				},
+			],
+			[
+				{
+					commands: ["pnpm build"],
+					phase: 0,
+				},
+			],
+			[
+				{
+					commands: ["pnpm build"],
+					phase: 0,
+				},
+			],
+		],
+		[
+			[
+				{
+					commands: ["pnpm build", "pnpm run"],
+					phase: 0,
+				},
+			],
+			[
+				{
+					commands: ["pnpm build"],
+					phase: 0,
+				},
+			],
+			[
+				{
+					commands: ["pnpm build", "pnpm run"],
+					phase: 0,
+				},
+			],
+		],
+		[
+			[
+				{
+					commands: ["pnpm build"],
+					phase: 0,
+				},
+			],
+			[
+				{
+					commands: ["pnpm build", "pnpm run"],
+					phase: 0,
+				},
+			],
+			[
+				{
+					commands: ["pnpm build", "pnpm run"],
+					phase: 0,
+				},
+			],
+		],
+		[
+			[
+				{
+					commands: ["pnpm build", "pnpm run"],
+					phase: 0,
+				},
+			],
+			[
+				{
+					commands: ["pnpm build", "pnpm run"],
+					phase: 0,
+				},
+			],
+			[
+				{
+					commands: ["pnpm build", "pnpm run"],
+					phase: 0,
+				},
+			],
+		],
+		[
+			[
+				{
+					commands: ["pnpm build", "pnpm run:a"],
+					phase: 0,
+				},
+			],
+			[
+				{
+					commands: ["pnpm build", "pnpm run:b"],
+					phase: 0,
+				},
+			],
+			[
+				{
+					commands: ["pnpm build", "pnpm run:a"],
+					phase: 0,
+				},
+				{
+					commands: ["pnpm build", "pnpm run:b"],
+					phase: 0,
+				},
+			],
+		],
+		[
+			[
+				{
+					commands: ["pnpm build", "pnpm run:a"],
+					phase: 0,
+				},
+			],
+			[
+				{
+					commands: ["pnpm build", "pnpm run:a", "pnpm run:b"],
+					phase: 0,
+				},
+			],
+			[
+				{
+					commands: ["pnpm build", "pnpm run:a", "pnpm run:b"],
+					phase: 0,
+				},
+			],
+		],
+		[
+			[
+				{
+					commands: ["pnpm build", "pnpm run:a", "pnpm run:b"],
+					phase: 0,
+				},
+			],
+			[
+				{
+					commands: ["pnpm build", "pnpm run:a"],
+					phase: 0,
+				},
+			],
+			[
+				{
+					commands: ["pnpm build", "pnpm run:a", "pnpm run:b"],
+					phase: 0,
+				},
+			],
+		],
+		[
+			[
+				{
+					commands: ["pnpm build", "pnpm run:a", "pnpm run:b"],
+					phase: 0,
+				},
+			],
+			[
+				{
+					commands: ["pnpm build", "pnpm run:c"],
+					phase: 0,
+				},
+			],
+			[
+				{
+					commands: ["pnpm build", "pnpm run:a", "pnpm run:b"],
+					phase: 0,
+				},
+				{
+					commands: ["pnpm build", "pnpm run:c"],
+					phase: 0,
+				},
+			],
+		],
+		[
+			[
+				{
+					commands: ["pnpm build"],
+					phase: 0,
+				},
+			],
+			[
+				{
+					commands: ["pnpm build"],
+					phase: 1,
+				},
+			],
+			[
+				{
+					commands: ["pnpm build"],
+					phase: 0,
+				},
+				{
+					commands: ["pnpm build"],
+					phase: 1,
+				},
+			],
+		],
+		[
+			[
+				{
+					commands: ["pnpm build"],
+					phase: 0,
+				},
+			],
+			[
+				{
+					commands: ["pnpm lint"],
+					phase: 1,
+				},
+			],
+			[
+				{
+					commands: ["pnpm build"],
+					phase: 0,
+				},
+				{
+					commands: ["pnpm lint"],
+					phase: 1,
+				},
+			],
+		],
+	])("%j and %j", (first, second, expected) => {
+		const actual = mergeCommands(first, second);
+
+		expect(actual).toEqual(expected);
+	});
+});

--- a/packages/create/src/mergers/mergeCommands.ts
+++ b/packages/create/src/mergers/mergeCommands.ts
@@ -1,0 +1,44 @@
+import { CreatedScript } from "../types/creations.js";
+
+export function mergeCommands(
+	first: CreatedScript[] | undefined,
+	second: CreatedScript[] | undefined,
+): CreatedScript[] | undefined {
+	if (!first) {
+		return second;
+	}
+
+	if (!second) {
+		return first;
+	}
+
+	const commandsByPhase = new Map<number, string[][]>();
+
+	for (const command of [...first, ...second]) {
+		const byPhase = commandsByPhase.get(command.phase);
+		if (!byPhase) {
+			commandsByPhase.set(command.phase, [command.commands.slice()]);
+			continue;
+		}
+
+		for (const existing of byPhase) {
+			if (existing.length <= command.commands.length) {
+				if (firstHasSameStart(existing, command.commands)) {
+					existing.push(...command.commands.slice(existing.length));
+				} else {
+					byPhase.push(command.commands);
+				}
+			} else if (!firstHasSameStart(command.commands, existing)) {
+				byPhase.push(command.commands);
+			}
+		}
+	}
+
+	return Array.from(commandsByPhase).flatMap(([phase, phaseCommands]) =>
+		phaseCommands.map((commands) => ({ commands, phase })),
+	);
+}
+
+function firstHasSameStart(first: string[], second: string[]) {
+	return first.every((entry, i) => entry === second[i]);
+}

--- a/packages/create/src/mergers/mergeCreations.test.ts
+++ b/packages/create/src/mergers/mergeCreations.test.ts
@@ -4,8 +4,8 @@ import { mergeCreations } from "./mergeCreations.js";
 
 const emptyCreation = {
 	addons: [],
-	commands: [],
 	files: {},
+	scripts: [],
 };
 
 describe("mergeCreations", () => {
@@ -13,33 +13,27 @@ describe("mergeCreations", () => {
 		const actual = mergeCreations(
 			{
 				...emptyCreation,
-				commands: ["run a", "run b"],
 				files: {
 					"README.md": "Hello, world!",
 					src: {
 						"index.ts": "",
 					},
 				},
+				scripts: [{ commands: ["run a", "run b"], phase: 0 }],
 			},
 			{
-				commands: ["run c", "run d"],
 				files: {
 					src: {
 						"second.ts": "// ...",
 					},
 				},
+				scripts: [{ commands: ["run c", "run d"], phase: 0 }],
 			},
 		);
 
 		expect(actual).toMatchInlineSnapshot(`
 			{
 			  "addons": [],
-			  "commands": [
-			    "run a",
-			    "run b",
-			    "run c",
-			    "run d",
-			  ],
 			  "files": {
 			    "README.md": "Hello, world!",
 			    "src": {
@@ -47,6 +41,22 @@ describe("mergeCreations", () => {
 			      "second.ts": "// ...",
 			    },
 			  },
+			  "scripts": [
+			    {
+			      "commands": [
+			        "run a",
+			        "run b",
+			      ],
+			      "phase": 0,
+			    },
+			    {
+			      "commands": [
+			        "run c",
+			        "run d",
+			      ],
+			      "phase": 0,
+			    },
+			  ],
 			}
 		`);
 	});

--- a/packages/create/src/mergers/mergeCreations.ts
+++ b/packages/create/src/mergers/mergeCreations.ts
@@ -9,7 +9,7 @@ export function mergeCreations<Options extends object>(
 ): Creation<Options> {
 	return {
 		addons: mergeAddons(first.addons, second.addons),
-		commands: mergeArrays(first.commands, second.commands),
 		files: mergeFileCreations(first.files, second.files, []) ?? {},
+		scripts: mergeArrays(first.scripts, second.scripts),
 	};
 }

--- a/packages/create/src/producers/producePreset.test.ts
+++ b/packages/create/src/producers/producePreset.test.ts
@@ -6,8 +6,8 @@ import { producePreset } from "./producePreset.js";
 
 const emptyCreation = {
 	addons: [],
-	commands: [],
 	files: {},
+	scripts: [],
 };
 
 describe("producePreset", () => {

--- a/packages/create/src/runners/applyCreation.ts
+++ b/packages/create/src/runners/applyCreation.ts
@@ -1,6 +1,7 @@
 import { DirectCreation } from "../types/creations.js";
 import { SystemContext } from "../types/system.js";
 import { applyFilesToSystem } from "./applyFilesToSystem.js";
+import { applyScriptsToSystem } from "./applyScriptsToSystem.js";
 
 export async function applyCreation(
 	creation: Partial<DirectCreation>,
@@ -11,6 +12,9 @@ export async function applyCreation(
 		await applyFilesToSystem(creation.files, system.fs, rootDirectory);
 	}
 
-	// TODO(#22): Implement shell command execution
+	if (creation.scripts) {
+		await applyScriptsToSystem(creation.scripts, system.runner);
+	}
+
 	// TODO(#23): Implement network request execution
 }

--- a/packages/create/src/runners/applyScriptsToSystem.test.ts
+++ b/packages/create/src/runners/applyScriptsToSystem.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, test, vi } from "vitest";
+
+import { applyScriptsToSystem } from "./applyScriptsToSystem.js";
+
+describe("applyCommandsToSystem", () => {
+	it("runs phase commands in different phases in order of phase", async () => {
+		const scripts = [
+			{ commands: ["c", "d"], phase: 1 },
+			{ commands: ["a", "b"], phase: 0 },
+		];
+		const runner = vi.fn();
+
+		await applyScriptsToSystem(scripts, runner);
+
+		expect(runner.mock.calls).toEqual([["a"], ["b"], ["c"], ["d"]]);
+	});
+
+	it("runs phase commands in the same phase in series", async () => {
+		const scripts = [
+			{ commands: ["a", "b"], phase: 0 },
+			{ commands: ["c", "d"], phase: 0 },
+		];
+		const runner = vi.fn();
+
+		await applyScriptsToSystem(scripts, runner);
+
+		expect(runner.mock.calls).toEqual([["a"], ["c"], ["b"], ["d"]]);
+	});
+
+	test("mixed phase commands", async () => {
+		const scripts = [
+			{ commands: ["a", "b"], phase: 2 },
+			{ commands: ["c", "d", "e"], phase: 1 },
+			{ commands: ["f", "g"], phase: 1 },
+			{ commands: ["h"], phase: 0 },
+		];
+		const runner = vi.fn();
+
+		await applyScriptsToSystem(scripts, runner);
+
+		expect(runner.mock.calls).toEqual([
+			["h"],
+			["c"],
+			["f"],
+			["d"],
+			["g"],
+			["e"],
+			["a"],
+			["b"],
+		]);
+	});
+});

--- a/packages/create/src/runners/applyScriptsToSystem.ts
+++ b/packages/create/src/runners/applyScriptsToSystem.ts
@@ -1,0 +1,24 @@
+import { CreatedScript } from "../types/creations.js";
+import { SystemRunner } from "../types/system.js";
+import { groupBy } from "../utils/groupBy.js";
+
+export async function applyScriptsToSystem(
+	scripts: CreatedScript[],
+	runner: SystemRunner,
+) {
+	const commandsByPhase = groupBy(scripts, (command) => command.phase);
+
+	const phaseKeys = Object.keys(commandsByPhase)
+		.map((key) => Number(key))
+		.sort();
+
+	for (const phase of phaseKeys) {
+		await Promise.all(
+			commandsByPhase[phase].map(async (command) => {
+				for (const script of command.commands) {
+					await runner(script);
+				}
+			}),
+		);
+	}
+}

--- a/packages/create/src/types/creations.ts
+++ b/packages/create/src/types/creations.ts
@@ -4,8 +4,8 @@
 import { BlockWithAddons } from "./blocks.js";
 
 export interface DirectCreation {
-	commands: (CreatedCommand | string)[];
 	files: CreatedFiles;
+	scripts: CreatedScript[];
 	// TODO: Network calls
 }
 
@@ -27,9 +27,9 @@ export interface CreatedBlockAddons<
 	block: BlockWithAddons<Addons, Options>;
 }
 
-export interface CreatedCommand {
-	phase: number; // TODO: Make an enum?
-	script: string;
+export interface CreatedScript {
+	commands: string[];
+	phase: number;
 }
 
 export interface CreatedFiles {

--- a/packages/create/src/utils/groupBy.ts
+++ b/packages/create/src/utils/groupBy.ts
@@ -1,0 +1,18 @@
+/**
+ * Ponyfill of ES2024's Object.groupBy, pending Node LTS supporting it.
+ */
+export function groupBy<T, K extends number | string>(
+	items: T[],
+	getKey: (item: T) => K,
+) {
+	const grouped = {} as Record<K, T[]>;
+
+	for (const item of items) {
+		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+		(grouped[getKey(item)] ??= []).push(item);
+	}
+
+	return Object.fromEntries(
+		Object.entries(grouped).sort(([a], [b]) => a.localeCompare(b)),
+	) as typeof grouped;
+}

--- a/packages/site/src/content/docs/engine/apis/runners.md
+++ b/packages/site/src/content/docs/engine/apis/runners.md
@@ -19,7 +19,7 @@ Each runner API takes in up to two arguments:
    - `rootDirectory: string` (default: `'.'`): The root directory to write files to
 
 :::note
-Runner APIs apply their generated objects to disk.
+Runner APIs apply their generated objects to disk, as well as executing any network requests and shell commands.
 For APIs that only create those objects in memory, see [Producers](./producers).
 :::
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #000
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Fills in merging and running of `scripts` creations, formerly known as `commands`. These objects contain `commands: string[]` as well as a `phase: number` that indicates when to start executing those commands in order relative to other scripts.

💖 