### PR TITLE
feat: added Creation requests

### DIFF
--- a/@
+++ b/@
@@ -1,0 +1,6 @@
+Merge branch 'main' into creation-requests
+# Please enter a commit message to explain why this merge is necessary,
+# especially if it merges an updated upstream into a topic branch.
+#
+# Lines starting with '#' will be ignored, and an empty message aborts
+# the commit.

--- a/packages/create-testers/package.json
+++ b/packages/create-testers/package.json
@@ -23,6 +23,9 @@
 	"scripts": {
 		"build": "tsc"
 	},
+	"dependencies": {
+		"octokit": "^4.0.2"
+	},
 	"devDependencies": {
 		"zod": "3.24.1"
 	},

--- a/packages/create-testers/src/createMockSystems.ts
+++ b/packages/create-testers/src/createMockSystems.ts
@@ -1,11 +1,23 @@
-import { TakeInput, WritingFileSystem } from "create";
+import { NativeSystem, TakeInput, WritingFileSystem } from "create";
+import { Octokit } from "octokit";
 
 import { MockSystemOptions } from "./types.js";
 import { createFailingFunction } from "./utils.js";
 
-export function createMockSystems(settings: MockSystemOptions = {}) {
-	const fetcher =
-		settings.fetcher ?? createFailingFunction("fetcher", "an input");
+export interface MockSystems {
+	system: NativeSystem;
+	take: TakeInput;
+}
+
+export function createMockSystems(
+	settings: MockSystemOptions = {},
+): MockSystems {
+	const fetch = settings.fetch ?? createFailingFunction("fetcher", "an input");
+
+	const fetchers = {
+		fetch,
+		octokit: new Octokit({ request: fetch }),
+	};
 
 	const fs: WritingFileSystem = {
 		readFile: createFailingFunction("fs.readFile", "an input"),
@@ -16,7 +28,7 @@ export function createMockSystems(settings: MockSystemOptions = {}) {
 
 	const runner = settings.runner ?? createFailingFunction("runner", "an input");
 
-	const system = { fetcher, fs, runner };
+	const system = { fetchers, fs, runner };
 
 	const take =
 		settings.take ??

--- a/packages/create-testers/src/testPreset.test.ts
+++ b/packages/create-testers/src/testPreset.test.ts
@@ -7,6 +7,7 @@ import { testPreset } from "./testPreset.js";
 const emptyCreation = {
 	addons: [],
 	files: {},
+	requests: [],
 	scripts: [],
 };
 

--- a/packages/create-testers/src/types.ts
+++ b/packages/create-testers/src/types.ts
@@ -1,7 +1,7 @@
 import { SystemRunner, TakeInput, WritingFileSystem } from "create";
 
 export interface MockSystemOptions {
-	fetcher?: typeof fetch;
+	fetch?: typeof fetch;
 	fs?: Partial<WritingFileSystem>;
 	runner?: SystemRunner;
 	take?: TakeInput;

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -26,6 +26,7 @@
 	},
 	"dependencies": {
 		"execa": "^9.5.2",
+		"hash-object": "^5.0.1",
 		"octokit": "^4.0.2",
 		"octokit-from-auth": "^0.3.0",
 		"zod": "^3.24.1"

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -26,6 +26,7 @@
 	},
 	"dependencies": {
 		"execa": "^9.5.2",
+		"octokit": "^4.0.2",
 		"octokit-from-auth": "^0.3.0",
 		"zod": "^3.24.1"
 	},

--- a/packages/create/src/creators/createInput.test.ts
+++ b/packages/create/src/creators/createInput.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test, vi } from "vitest";
 import { z } from "zod";
 
+import { createSystemFetchers } from "../system/createSystemFetchers.js";
 import { createInput } from "./createInput.js";
 
 describe("createInput", () => {
@@ -12,7 +13,7 @@ describe("createInput", () => {
 		});
 
 		const actual = input({
-			fetcher: vi.fn(),
+			fetchers: createSystemFetchers(vi.fn()),
 			fs: { readFile: vi.fn() },
 			runner: vi.fn(),
 			take: vi.fn(),
@@ -35,7 +36,7 @@ describe("createInput", () => {
 			args: {
 				offset: 1000,
 			},
-			fetcher: vi.fn(),
+			fetchers: createSystemFetchers(vi.fn()),
 			fs: { readFile: vi.fn() },
 			runner: vi.fn(),
 			take: vi.fn(),

--- a/packages/create/src/mergers/applyMerger.test.ts
+++ b/packages/create/src/mergers/applyMerger.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { applyMerger } from "./applyMerger.js";
+
+const fallback = "c";
+
+describe("applyMerger", () => {
+	it("returns second when first is undefined", () => {
+		const second = "b";
+
+		const actual = applyMerger(undefined, second, (a, b) => a + b, fallback);
+
+		expect(actual).toBe(second);
+	});
+
+	it("returns first when second is undefined", () => {
+		const first = "a";
+
+		const actual = applyMerger(first, undefined, (a, b) => a + b, fallback);
+
+		expect(actual).toBe(first);
+	});
+
+	it("returns fallback when first and second are undefined", () => {
+		const actual = applyMerger(undefined, undefined, (a, b) => a + b, fallback);
+
+		expect(actual).toBe(fallback);
+	});
+	it("returns the merger when first and second are defined", () => {
+		const first = "a";
+		const second = "b";
+
+		const actual = applyMerger(first, second, (a, b) => a + b, fallback);
+
+		expect(actual).toBe("ab");
+	});
+});

--- a/packages/create/src/mergers/applyMerger.ts
+++ b/packages/create/src/mergers/applyMerger.ts
@@ -1,0 +1,12 @@
+export function applyMerger<T>(
+	first: T | undefined,
+	second: T | undefined,
+	merger: (first: T, second: T) => T,
+	fallback: T,
+) {
+	if (first == null || second == null) {
+		return second ?? first ?? fallback;
+	}
+
+	return merger(first, second);
+}

--- a/packages/create/src/mergers/mergeAddons.test.ts
+++ b/packages/create/src/mergers/mergeAddons.test.ts
@@ -68,7 +68,12 @@ describe("mergeAddons", () => {
 		[
 			[{ addons: [{ values: ["a"] }], block: blockFirst }],
 			[{ addons: [{ values: ["a"] }], block: blockFirst }],
-			[{ addons: [{ values: ["a"] }, { values: ["a"] }], block: blockFirst }],
+			[{ addons: [{ values: ["a"] }], block: blockFirst }],
+		],
+		[
+			[{ addons: [{ values: ["a", { b: "c" }] }], block: blockFirst }],
+			[{ addons: [{ values: ["a", { b: "c" }] }], block: blockFirst }],
+			[{ addons: [{ values: ["a", { b: "c" }] }], block: blockFirst }],
 		],
 		[
 			[{ addons: [{ value: {} }], block: blockFirst }],
@@ -133,6 +138,36 @@ describe("mergeAddons", () => {
 					addons: [
 						{ name: "First", steps: ["a", "b"] },
 						{ name: "Second", steps: ["c", "d"] },
+					],
+					block: blockFirst,
+				},
+			],
+		],
+		[
+			[
+				{
+					addons: [
+						{ name: "First", steps: ["a", "b"] },
+						{ name: "Second", steps: ["c", "d"] },
+					],
+					block: blockFirst,
+				},
+			],
+			[
+				{
+					addons: [
+						{ name: "Second", steps: ["c", "d"] },
+						{ name: "Third", steps: ["e", "f"] },
+					],
+					block: blockFirst,
+				},
+			],
+			[
+				{
+					addons: [
+						{ name: "First", steps: ["a", "b"] },
+						{ name: "Second", steps: ["c", "d"] },
+						{ name: "Third", steps: ["e", "f"] },
 					],
 					block: blockFirst,
 				},

--- a/packages/create/src/mergers/mergeAddons.test.ts
+++ b/packages/create/src/mergers/mergeAddons.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from "vitest";
+
+import { BlockWithAddons } from "../types/blocks.js";
+import { mergeAddons } from "./mergeAddons.js";
+
+const blockFirst = {} as BlockWithAddons<object, object>;
+const blockSecond = {} as BlockWithAddons<object, object>;
+
+const sharedObject = { value: true };
+
+describe("mergeAddons", () => {
+	test.each([
+		[
+			[{ addons: ["a"], block: blockFirst }],
+			[{ addons: ["a"], block: blockFirst }],
+			[{ addons: ["a"], block: blockFirst }],
+		],
+		[
+			[{ addons: ["a"], block: blockFirst }],
+			[{ addons: ["b"], block: blockFirst }],
+			[{ addons: ["a", "b"], block: blockFirst }],
+		],
+		[
+			[{ addons: ["a", "b"], block: blockFirst }],
+			[{ addons: ["b"], block: blockFirst }],
+			[{ addons: ["a", "b"], block: blockFirst }],
+		],
+		[
+			[{ addons: ["a", "b"], block: blockFirst }],
+			[{ addons: ["b", "c"], block: blockFirst }],
+			[{ addons: ["a", "b", "c"], block: blockFirst }],
+		],
+		[
+			[{ addons: ["a", "b"], block: blockFirst }],
+			[{ addons: ["b", "c", "d"], block: blockFirst }],
+			[{ addons: ["a", "b", "c", "d"], block: blockFirst }],
+		],
+		[
+			[{ addons: ["a"], block: blockFirst }],
+			[{ addons: [null], block: blockFirst }],
+			[{ addons: ["a"], block: blockFirst }],
+		],
+		[
+			[{ addons: ["a", undefined, null, "b"], block: blockFirst }],
+			[{ addons: [null], block: blockFirst }],
+			[{ addons: ["a", "b"], block: blockFirst }],
+		],
+		[
+			[{ addons: ["a"], block: blockFirst }],
+			[{ addons: ["a"], block: blockSecond }],
+			[
+				{ addons: ["a"], block: blockFirst },
+				{ addons: ["a"], block: blockSecond },
+			],
+		],
+		[
+			[{ addons: [{ values: ["a"] }], block: blockFirst }],
+			[{ addons: [{ values: ["a"] }], block: blockFirst }],
+			[{ addons: [{ values: ["a"] }], block: blockFirst }],
+		],
+		[
+			[{ addons: ["a"], block: blockFirst }],
+			[{ addons: [123], block: blockFirst }],
+			new Error(`Mismatched types in Block Addons: string and number.`),
+		],
+		[
+			[{ addons: [{ value: true }], block: blockFirst }],
+			[{ addons: [123], block: blockFirst }],
+			new Error(`Mismatched types in Block Addons: object and number.`),
+		],
+		[
+			[{ addons: [{ value: {} }], block: blockFirst }],
+			[{ addons: [{ value: { inner: true } }], block: blockFirst }],
+			[{ addons: [{ value: { inner: true } }], block: blockFirst }],
+		],
+		[
+			[{ addons: [{ value: { inner: true } }], block: blockFirst }],
+			[{ addons: [{ value: {} }], block: blockFirst }],
+			[{ addons: [{ value: { inner: true } }], block: blockFirst }],
+		],
+		[
+			[{ addons: [{ value: true }], block: blockFirst }],
+			[{ addons: [{ value: { inner: true } }], block: blockFirst }],
+			new Error(`Mismatched types in Block Addons: boolean and object.`),
+		],
+		[
+			[{ addons: [{ value: [true] }], block: blockFirst }],
+			[{ addons: [{ value: { inner: true } }], block: blockFirst }],
+			new Error(`Mismatched types in Block Addons: array and non-array.`),
+		],
+		[
+			[{ addons: [{ value: { inner: true } }], block: blockFirst }],
+			[{ addons: [{ value: [true] }], block: blockFirst }],
+			new Error(`Mismatched types in Block Addons: non-array and array.`),
+		],
+		[
+			[{ addons: [{ value: { inner: false } }], block: blockFirst }],
+			[{ addons: [{ value: { inner: true } }], block: blockFirst }],
+			new Error(`Mismatched values in Block Addons: false and true.`),
+		],
+		[
+			[{ addons: [{ value: sharedObject }], block: blockFirst }],
+			[{ addons: [{ value: sharedObject }], block: blockFirst }],
+			[{ addons: [{ value: sharedObject }], block: blockFirst }],
+		],
+	])("%j and %j", (first, second, expected) => {
+		const act = () => mergeAddons(first, second);
+
+		if (expected instanceof Error) {
+			expect(act).toThrow(expected);
+		} else {
+			expect(act()).toEqual(expected);
+		}
+	});
+});

--- a/packages/create/src/mergers/mergeAddons.test.ts
+++ b/packages/create/src/mergers/mergeAddons.test.ts
@@ -1,19 +1,31 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 
 import { BlockWithAddons } from "../types/blocks.js";
 import { mergeAddons } from "./mergeAddons.js";
 
-const blockFirst = {} as BlockWithAddons<object, object>;
-const blockSecond = {} as BlockWithAddons<object, object>;
+const blockFirst: BlockWithAddons<object, object> = Object.assign(vi.fn(), {
+	about: { name: "Block First" },
+	produce: vi.fn(),
+});
+
+const blockSecond: BlockWithAddons<object, object> = Object.assign(vi.fn(), {
+	about: { name: "BlockSecond" },
+	produce: vi.fn(),
+});
 
 const sharedObject = { value: true };
 
 describe("mergeAddons", () => {
 	test.each([
 		[
+			[{ addons: [null], block: blockFirst }],
+			[{ addons: [undefined], block: blockFirst }],
+			[{ addons: [], block: blockFirst }],
+		],
+		[
 			[{ addons: ["a"], block: blockFirst }],
-			[{ addons: ["a"], block: blockFirst }],
-			[{ addons: ["a"], block: blockFirst }],
+			[{ addons: [123], block: blockFirst }],
+			[{ addons: ["a", 123], block: blockFirst }],
 		],
 		[
 			[{ addons: ["a"], block: blockFirst }],
@@ -56,60 +68,77 @@ describe("mergeAddons", () => {
 		[
 			[{ addons: [{ values: ["a"] }], block: blockFirst }],
 			[{ addons: [{ values: ["a"] }], block: blockFirst }],
-			[{ addons: [{ values: ["a"] }], block: blockFirst }],
-		],
-		[
-			[{ addons: ["a"], block: blockFirst }],
-			[{ addons: [123], block: blockFirst }],
-			new Error(`Mismatched types in Block Addons: string and number.`),
-		],
-		[
-			[{ addons: [{ value: true }], block: blockFirst }],
-			[{ addons: [123], block: blockFirst }],
-			new Error(`Mismatched types in Block Addons: object and number.`),
+			[{ addons: [{ values: ["a"] }, { values: ["a"] }], block: blockFirst }],
 		],
 		[
 			[{ addons: [{ value: {} }], block: blockFirst }],
 			[{ addons: [{ value: { inner: true } }], block: blockFirst }],
-			[{ addons: [{ value: { inner: true } }], block: blockFirst }],
+			[
+				{
+					addons: [{ value: {} }, { value: { inner: true } }],
+					block: blockFirst,
+				},
+			],
 		],
 		[
 			[{ addons: [{ value: { inner: true } }], block: blockFirst }],
 			[{ addons: [{ value: {} }], block: blockFirst }],
-			[{ addons: [{ value: { inner: true } }], block: blockFirst }],
-		],
-		[
-			[{ addons: [{ value: true }], block: blockFirst }],
-			[{ addons: [{ value: { inner: true } }], block: blockFirst }],
-			new Error(`Mismatched types in Block Addons: boolean and object.`),
-		],
-		[
-			[{ addons: [{ value: [true] }], block: blockFirst }],
-			[{ addons: [{ value: { inner: true } }], block: blockFirst }],
-			new Error(`Mismatched types in Block Addons: array and non-array.`),
+			[
+				{
+					addons: [{ value: { inner: true } }, { value: {} }],
+					block: blockFirst,
+				},
+			],
 		],
 		[
 			[{ addons: [{ value: { inner: true } }], block: blockFirst }],
 			[{ addons: [{ value: [true] }], block: blockFirst }],
-			new Error(`Mismatched types in Block Addons: non-array and array.`),
+			[
+				{
+					addons: [{ value: { inner: true } }, { value: [true] }],
+					block: blockFirst,
+				},
+			],
 		],
 		[
 			[{ addons: [{ value: { inner: false } }], block: blockFirst }],
 			[{ addons: [{ value: { inner: true } }], block: blockFirst }],
-			new Error(`Mismatched values in Block Addons: false and true.`),
+			[
+				{
+					addons: [{ value: { inner: false } }, { value: { inner: true } }],
+					block: blockFirst,
+				},
+			],
 		],
 		[
-			[{ addons: [{ value: sharedObject }], block: blockFirst }],
-			[{ addons: [{ value: sharedObject }], block: blockFirst }],
-			[{ addons: [{ value: sharedObject }], block: blockFirst }],
+			[{ addons: [sharedObject], block: blockFirst }],
+			[{ addons: [sharedObject], block: blockFirst }],
+			[{ addons: [sharedObject], block: blockFirst }],
+		],
+		[
+			[
+				{
+					addons: [{ name: "First", steps: ["a", "b"] }],
+					block: blockFirst,
+				},
+			],
+			[
+				{
+					addons: [{ name: "Second", steps: ["c", "d"] }],
+					block: blockFirst,
+				},
+			],
+			[
+				{
+					addons: [
+						{ name: "First", steps: ["a", "b"] },
+						{ name: "Second", steps: ["c", "d"] },
+					],
+					block: blockFirst,
+				},
+			],
 		],
 	])("%j and %j", (first, second, expected) => {
-		const act = () => mergeAddons(first, second);
-
-		if (expected instanceof Error) {
-			expect(act).toThrow(expected);
-		} else {
-			expect(act()).toEqual(expected);
-		}
+		expect(mergeAddons(first, second)).toEqual(expected);
 	});
 });

--- a/packages/create/src/mergers/mergeAddons.ts
+++ b/packages/create/src/mergers/mergeAddons.ts
@@ -1,9 +1,109 @@
+import { BlockWithAddons } from "../types/blocks.js";
 import { CreatedBlockAddons } from "../types/creations.js";
 
-export function mergeAddons<Addons extends object, Options extends object>(
-	first: CreatedBlockAddons<Addons, Options>[] | undefined,
-	second: CreatedBlockAddons<Addons, Options>[] | undefined,
+export function mergeAddons<Options extends object | unknown[]>(
+	first: CreatedBlockAddons<object, Options>[],
+	second: CreatedBlockAddons<object, Options>[],
+): CreatedBlockAddons<object, Options>[] {
+	const byBlock = new Map<BlockWithAddons<object, Options>, object>();
+
+	for (const { addons, block } of [...first, ...second]) {
+		byBlock.set(block, mergeBlockAddons(byBlock.get(block), addons) as object);
+	}
+
+	return Array.from(byBlock).map(([block, addons]) => ({ addons, block }));
+}
+
+function isNotNullish(value: unknown) {
+	return value != null;
+}
+
+function mergeBlockAddonArrays(firsts: unknown[], seconds: unknown[]) {
+	const firstNonNullish = firsts.filter(isNotNullish);
+	const secondNonNullish = seconds.filter(isNotNullish);
+
+	return mergeBlockAddonArraysNonNullish(firstNonNullish, secondNonNullish);
+}
+
+function mergeBlockAddonArraysNonNullish(
+	firsts: unknown[],
+	seconds: unknown[],
 ) {
-	// ...TODO: actually merge
-	return [...(first ?? []), ...(second ?? [])];
+	const results: unknown[] = [];
+
+	for (let i = 0; i < firsts.length; i += 1) {
+		const first = firsts[i];
+		const second = seconds[i];
+
+		if (typeof first === typeof second && typeof first !== "object") {
+			results.push(first);
+
+			if (first !== second) {
+				results.push(second);
+			}
+		} else {
+			results.push(mergeBlockAddonValues(first, second));
+		}
+	}
+
+	for (let i = seconds.length; i < firsts.length; i += 1) {
+		results.push(firsts[i]);
+	}
+
+	for (let i = firsts.length; i < seconds.length; i += 1) {
+		results.push(seconds[i]);
+	}
+
+	return Array.from(new Set(results));
+}
+
+function mergeBlockAddons(first: unknown, second: unknown) {
+	if (Array.isArray(first) && Array.isArray(second)) {
+		return mergeBlockAddonArrays(first, second);
+	}
+
+	return mergeBlockAddonValues(first, second);
+}
+
+function mergeBlockAddonValues(first: unknown, second: unknown) {
+	if (first == null || second == null) {
+		return first ?? second;
+	}
+
+	if (typeof first !== typeof second) {
+		throw new Error(
+			`Mismatched types in Block Addons: ${typeof first} and ${typeof second}.`,
+		);
+	}
+
+	if (Array.isArray(first)) {
+		if (!Array.isArray(second)) {
+			throw new Error(`Mismatched types in Block Addons: array and non-array.`);
+		}
+
+		return mergeBlockAddonArrays(first, second);
+	} else if (Array.isArray(second)) {
+		throw new Error(`Mismatched types in Block Addons: non-array and array.`);
+	}
+
+	if (typeof first !== "object") {
+		if (first !== second) {
+			throw new Error(
+				`Mismatched values in Block Addons: ${first as string} and ${second as string}.`,
+			);
+		}
+
+		return first;
+	}
+
+	const result: Record<string, unknown> = { ...first };
+
+	for (const [key, value] of Object.entries(second)) {
+		result[key] =
+			key in result
+				? mergeBlockAddonValues(first[key as keyof typeof first], value)
+				: value;
+	}
+
+	return result;
 }

--- a/packages/create/src/mergers/mergeAddons.ts
+++ b/packages/create/src/mergers/mergeAddons.ts
@@ -1,3 +1,5 @@
+import hashObject from "hash-object";
+
 import { BlockWithAddons } from "../types/blocks.js";
 import { CreatedBlockAddons } from "../types/creations.js";
 
@@ -36,29 +38,19 @@ function mergeBlockAddonArraysNonNullish(
 	firsts: unknown[],
 	seconds: unknown[],
 ) {
-	const results: unknown[] = [];
-	const sharedLength = Math.min(firsts.length, seconds.length);
+	const seen = new Set<unknown>();
 
-	for (let i = 0; i < sharedLength; i += 1) {
-		const first = firsts[i];
-		const second = seconds[i];
+	return [...firsts, ...seconds].filter((value) => {
+		const identity =
+			value && typeof value === "object" ? hashObject(value) : value;
 
-		if (first === second) {
-			results.push(first);
-		} else {
-			results.push(first, second);
+		if (seen.has(identity)) {
+			return false;
 		}
-	}
 
-	for (let i = seconds.length; i < firsts.length; i += 1) {
-		results.push(firsts[i]);
-	}
-
-	for (let i = firsts.length; i < seconds.length; i += 1) {
-		results.push(seconds[i]);
-	}
-
-	return Array.from(new Set(results));
+		seen.add(identity);
+		return true;
+	});
 }
 
 function mergeBlockAddons(first: unknown, second: unknown) {

--- a/packages/create/src/mergers/mergeArrays.ts
+++ b/packages/create/src/mergers/mergeArrays.ts
@@ -1,5 +1,0 @@
-import { isNotUndefined } from "../utils/values.js";
-
-export function mergeArrays<T>(...arrays: (T[] | undefined)[]) {
-	return arrays.filter(isNotUndefined).flat();
-}

--- a/packages/create/src/mergers/mergeCreations.test.ts
+++ b/packages/create/src/mergers/mergeCreations.test.ts
@@ -5,6 +5,7 @@ import { mergeCreations } from "./mergeCreations.js";
 const emptyCreation = {
 	addons: [],
 	files: {},
+	requests: [],
 	scripts: [],
 };
 
@@ -41,6 +42,7 @@ describe("mergeCreations", () => {
 			      "second.ts": "// ...",
 			    },
 			  },
+			  "requests": [],
 			  "scripts": [
 			    {
 			      "commands": [

--- a/packages/create/src/mergers/mergeCreations.ts
+++ b/packages/create/src/mergers/mergeCreations.ts
@@ -1,15 +1,18 @@
 import { Creation } from "../types/creations.js";
+import { applyMerger } from "./applyMerger.js";
 import { mergeAddons } from "./mergeAddons.js";
-import { mergeArrays } from "./mergeArrays.js";
 import { mergeFileCreations } from "./mergeFileCreations.js";
+import { mergeRequests } from "./mergeRequests.js";
+import { mergeScripts } from "./mergeScripts.js";
 
 export function mergeCreations<Options extends object>(
 	first: Partial<Creation<Options>>,
 	second: Partial<Creation<Options>>,
 ): Creation<Options> {
 	return {
-		addons: mergeAddons(first.addons, second.addons),
-		files: mergeFileCreations(first.files, second.files, []) ?? {},
-		scripts: mergeArrays(first.scripts, second.scripts),
+		addons: applyMerger(first.addons, second.addons, mergeAddons, []),
+		files: applyMerger(first.files, second.files, mergeFileCreations, {}),
+		requests: applyMerger(first.requests, second.requests, mergeRequests, []),
+		scripts: applyMerger(first.scripts, second.scripts, mergeScripts, []),
 	};
 }

--- a/packages/create/src/mergers/mergeFileCreations.test.ts
+++ b/packages/create/src/mergers/mergeFileCreations.test.ts
@@ -3,24 +3,16 @@ import { describe, expect, test } from "vitest";
 import { CreatedFiles } from "../types/creations.js";
 import { mergeFileCreations } from "./mergeFileCreations.js";
 
-const path = ["test"];
-
 describe("mergeFileCreations", () => {
 	test.each([
-		[undefined, undefined, undefined],
-		[{}, undefined, {}],
-		[undefined, {}, {}],
 		[{}, {}, {}],
+		[{ a: false }, { a: undefined }, {}],
 		[{ a: "" }, { a: "" }, { a: "" }],
 		[{ a: "" }, { b: "" }, { a: "", b: "" }],
-		[{ a: "1" }, { a: "2" }, "Conflicting created files at path: 'test/a'."],
-		[{ a: "1" }, { a: ["2"] }, "Conflicting created files at path: 'test/a'."],
-		[{ a: ["1"] }, { a: "2" }, "Conflicting created files at path: 'test/a'."],
-		[
-			{ a: ["1"] },
-			{ a: ["2"] },
-			"Conflicting created files at path: 'test/a'.",
-		],
+		[{ a: "1" }, { a: "2" }, "Conflicting created files at path: 'a'."],
+		[{ a: "1" }, { a: ["2"] }, "Conflicting created files at path: 'a'."],
+		[{ a: ["1"] }, { a: "2" }, "Conflicting created files at path: 'a'."],
+		[{ a: ["1"] }, { a: ["2"] }, "Conflicting created files at path: 'a'."],
 		[{ a: {} }, { a: {} }, { a: {} }],
 		[{ a: {} }, { a: { b: "" } }, { a: { b: "" } }],
 		[{ a: { b: "" } }, { a: {} }, { a: { b: "" } }],
@@ -28,28 +20,20 @@ describe("mergeFileCreations", () => {
 		[
 			{ a: "" },
 			{ a: {} },
-			"Conflicting created directory and file at path: 'test/a'.",
+			"Conflicting created directory and file at path: 'a'.",
 		],
 		[
 			{ a: {} },
 			{ a: "" },
-			"Conflicting created directory and file at path: 'test/a'.",
+			"Conflicting created directory and file at path: 'a'.",
 		],
-	] satisfies [
-		CreatedFiles | undefined,
-		CreatedFiles | undefined,
-		CreatedFiles | string | undefined,
-	][])(
+	] satisfies [CreatedFiles, CreatedFiles, CreatedFiles | string][])(
 		"%j with %j",
-		(
-			first: CreatedFiles | undefined,
-			second: CreatedFiles | undefined,
-			expected?: object | string,
-		) => {
+		(first: CreatedFiles, second: CreatedFiles, expected?: object | string) => {
 			if (typeof expected === "string") {
-				expect(() => mergeFileCreations(first, second, path)).toThrow(expected);
+				expect(() => mergeFileCreations(first, second)).toThrow(expected);
 			} else {
-				expect(mergeFileCreations(first, second, path)).toEqual(expected);
+				expect(mergeFileCreations(first, second)).toEqual(expected);
 			}
 		},
 	);

--- a/packages/create/src/mergers/mergeFileCreations.ts
+++ b/packages/create/src/mergers/mergeFileCreations.ts
@@ -8,7 +8,7 @@ export function mergeFileCreations(
 	return mergeFileCreationsWorker(firsts, seconds, []);
 }
 
-export function mergeFileCreationsWorker(
+function mergeFileCreationsWorker(
 	firsts: CreatedFiles,
 	seconds: CreatedFiles,
 	path: string[],

--- a/packages/create/src/mergers/mergeFileCreations.ts
+++ b/packages/create/src/mergers/mergeFileCreations.ts
@@ -2,18 +2,17 @@ import { CreatedFiles } from "../types/creations.js";
 import { mergeFileEntries } from "./mergeFileEntries.js";
 
 export function mergeFileCreations(
-	firsts: CreatedFiles | undefined,
-	seconds: CreatedFiles | undefined,
+	firsts: CreatedFiles,
+	seconds: CreatedFiles,
+) {
+	return mergeFileCreationsWorker(firsts, seconds, []);
+}
+
+export function mergeFileCreationsWorker(
+	firsts: CreatedFiles,
+	seconds: CreatedFiles,
 	path: string[],
 ) {
-	if (!firsts) {
-		return seconds;
-	}
-
-	if (!seconds) {
-		return firsts;
-	}
-
 	const result: CreatedFiles = { ...firsts };
 
 	for (const i in seconds) {
@@ -37,7 +36,7 @@ export function mergeFileCreations(
 		}
 
 		result[i] = firstIsDirectory
-			? mergeFileCreations(first, second as CreatedFiles, nextPath)
+			? mergeFileCreationsWorker(first, second as CreatedFiles, nextPath)
 			: mergeFileEntries(first, second, nextPath);
 	}
 

--- a/packages/create/src/mergers/mergeRequests.test.ts
+++ b/packages/create/src/mergers/mergeRequests.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { mergeRequests } from "./mergeRequests.js";
+
+describe("mergeRequests", () => {
+	it("returns both requests when they have different ids", () => {
+		const first = {
+			id: "a",
+			send: vi.fn(),
+		};
+		const second = {
+			id: "b",
+			send: vi.fn(),
+		};
+
+		const actual = mergeRequests([first], [second]);
+
+		expect(actual).toEqual([first, second]);
+	});
+
+	it("returns only the second request when they have the same id", () => {
+		const first = {
+			id: "a",
+			send: vi.fn(),
+		};
+		const second = {
+			id: "a",
+			send: vi.fn(),
+		};
+
+		const actual = mergeRequests([first], [second]);
+
+		expect(actual).toEqual([second]);
+	});
+});

--- a/packages/create/src/mergers/mergeRequests.ts
+++ b/packages/create/src/mergers/mergeRequests.ts
@@ -1,0 +1,14 @@
+import { CreatedRequest } from "../types/creations.js";
+
+export function mergeRequests(
+	firsts: CreatedRequest[],
+	seconds: CreatedRequest[],
+) {
+	const byId = new Map<string, CreatedRequest>();
+
+	for (const request of [...firsts, ...seconds]) {
+		byId.set(request.id, request);
+	}
+
+	return Array.from(byId.values());
+}

--- a/packages/create/src/mergers/mergeScripts.test.ts
+++ b/packages/create/src/mergers/mergeScripts.test.ts
@@ -4,31 +4,11 @@ import { mergeScripts } from "./mergeScripts.js";
 
 describe("mergeScripts", () => {
 	test.each([
-		[undefined, undefined, undefined],
-		[[], undefined, []],
-		[["a"], undefined, ["a"]],
-		[undefined, [], []],
-		[undefined, ["a"], ["a"]],
 		[[], [], []],
 		[[], ["a"], ["a"]],
 		[["a"], [], ["a"]],
 		[["a"], ["a"], ["a"]],
 		[["a"], ["b"], ["a", "b"]],
-		[
-			[
-				{
-					commands: ["pnpm build"],
-					phase: 0,
-				},
-			],
-			undefined,
-			[
-				{
-					commands: ["pnpm build"],
-					phase: 0,
-				},
-			],
-		],
 		[
 			[
 				{

--- a/packages/create/src/mergers/mergeScripts.ts
+++ b/packages/create/src/mergers/mergeScripts.ts
@@ -1,17 +1,9 @@
 import { CreatedScript } from "../types/creations.js";
 
 export function mergeScripts(
-	first: CreatedScript[] | undefined,
-	second: CreatedScript[] | undefined,
-): CreatedScript[] | undefined {
-	if (!first) {
-		return second;
-	}
-
-	if (!second) {
-		return first;
-	}
-
+	first: CreatedScript[],
+	second: CreatedScript[],
+): CreatedScript[] {
 	const commandsByPhase = new Map<number, string[][]>();
 	const commandsWithoutPhase: string[] = [];
 

--- a/packages/create/src/producers/executePresetBlocks.test.ts
+++ b/packages/create/src/producers/executePresetBlocks.test.ts
@@ -2,11 +2,12 @@ import { describe, expect, it, test, vi } from "vitest";
 import { z } from "zod";
 
 import { createBase } from "../creators/createBase.js";
+import { createSystemFetchers } from "../system/createSystemFetchers.js";
 import { executePresetBlocks } from "./executePresetBlocks.js";
 
 const context = {
 	directory: ".",
-	fetcher: vi.fn(),
+	fetchers: createSystemFetchers(vi.fn()),
 	fs: { readFile: vi.fn(), writeDirectory: vi.fn(), writeFile: vi.fn() },
 	runner: vi.fn(),
 	take: vi.fn(),
@@ -50,6 +51,7 @@ describe("runPreset", () => {
 			files: {
 				"README.md": "Hello, world!",
 			},
+			requests: [],
 			scripts: [],
 		});
 	});
@@ -93,6 +95,7 @@ describe("runPreset", () => {
 				files: {
 					"README.md": "Hello, world!",
 				},
+				requests: [],
 				scripts: [],
 			});
 		});
@@ -111,6 +114,7 @@ describe("runPreset", () => {
 					"data.txt": "Hello, world!",
 					"README.md": "Hello, world!",
 				},
+				requests: [],
 				scripts: [],
 			});
 		});

--- a/packages/create/src/producers/executePresetBlocks.ts
+++ b/packages/create/src/producers/executePresetBlocks.ts
@@ -18,7 +18,7 @@ export function executePresetBlocks<OptionsShape extends AnyShape>(
 ) {
 	type Options = InferredObject<OptionsShape>;
 
-	// From engine/runtime/merging.md:
+	// From engine/runtime/execution.md:
 	// This engine continuously re-runs Blocks until no new Args are provided.
 
 	const blockProductions = new Map<
@@ -82,6 +82,7 @@ export function executePresetBlocks<OptionsShape extends AnyShape>(
 		{
 			addons: [],
 			files: {},
+			requests: [],
 			scripts: [],
 		},
 	);

--- a/packages/create/src/producers/producePreset.test.ts
+++ b/packages/create/src/producers/producePreset.test.ts
@@ -7,6 +7,7 @@ import { producePreset } from "./producePreset.js";
 const emptyCreation = {
 	addons: [],
 	files: {},
+	requests: [],
 	scripts: [],
 };
 

--- a/packages/create/src/runners/applyCreation.ts
+++ b/packages/create/src/runners/applyCreation.ts
@@ -1,6 +1,7 @@
 import { DirectCreation } from "../types/creations.js";
 import { SystemContext } from "../types/system.js";
 import { applyFilesToSystem } from "./applyFilesToSystem.js";
+import { applyRequestsToSystem } from "./applyRequestsToSystem.js";
 import { applyScriptsToSystem } from "./applyScriptsToSystem.js";
 
 export async function applyCreation(
@@ -11,9 +12,9 @@ export async function applyCreation(
 		await applyFilesToSystem(creation.files, system.fs, system.directory);
 	}
 
-	if (creation.scripts) {
-		await applyScriptsToSystem(creation.scripts, system.runner);
-	}
-
-	// TODO(#23): Implement network request execution
+	await Promise.all([
+		creation.scripts && applyScriptsToSystem(creation.scripts, system.runner),
+		creation.requests &&
+			applyRequestsToSystem(creation.requests, system.fetchers),
+	]);
 }

--- a/packages/create/src/runners/applyRequestsToSystem.ts
+++ b/packages/create/src/runners/applyRequestsToSystem.ts
@@ -1,0 +1,13 @@
+import { CreatedRequest } from "../types/creations.js";
+import { SystemFetchers } from "../types/system.js";
+
+export async function applyRequestsToSystem(
+	requests: CreatedRequest[],
+	fetchers: SystemFetchers,
+) {
+	await Promise.all(
+		requests.map(async (request) => {
+			await request.send(fetchers);
+		}),
+	);
+}

--- a/packages/create/src/system/createSystemContext.ts
+++ b/packages/create/src/system/createSystemContext.ts
@@ -1,5 +1,6 @@
 import { TakeInput } from "../types/inputs.js";
 import { NativeSystem, SystemContext } from "../types/system.js";
+import { createSystemFetchers } from "./createSystemFetchers.js";
 import { createSystemRunner } from "./createSystemRunner.js";
 import { createWritingFileSystem } from "./createWritingFileSystem.js";
 
@@ -10,8 +11,8 @@ export interface SystemContextSettings extends Partial<NativeSystem> {
 export function createSystemContext(
 	settings: SystemContextSettings,
 ): SystemContext {
-	const system = {
-		fetcher: settings.fetcher ?? fetch,
+	const system: NativeSystem = {
+		fetchers: settings.fetchers ?? createSystemFetchers(),
 		fs: settings.fs ?? createWritingFileSystem(),
 		runner: settings.runner ?? createSystemRunner(settings.directory),
 	};

--- a/packages/create/src/system/createSystemFetchers.ts
+++ b/packages/create/src/system/createSystemFetchers.ts
@@ -1,0 +1,10 @@
+import { Octokit } from "octokit";
+
+import { SystemFetchers } from "../types/system.js";
+
+export function createSystemFetchers(fetch = globalThis.fetch): SystemFetchers {
+	return {
+		fetch,
+		octokit: new Octokit(),
+	};
+}

--- a/packages/create/src/types/creations.ts
+++ b/packages/create/src/types/creations.ts
@@ -2,6 +2,7 @@
 /* eslint-disable @typescript-eslint/consistent-indexed-object-style */
 
 import { BlockWithAddons } from "./blocks.js";
+import { SystemFetchers } from "./system.js";
 
 export interface CreatedBlockAddons<
 	Addons extends object,
@@ -30,6 +31,13 @@ export interface CreatedFiles {
 	[i: string]: CreatedFileEntry | undefined;
 }
 
+export interface CreatedRequest {
+	id: string;
+	send: CreatedRequestSender;
+}
+
+export type CreatedRequestSender = (fetchers: SystemFetchers) => Promise<void>;
+
 export type CreatedScript = CreatedScriptWithPhase | string;
 
 export interface CreatedScriptWithPhase {
@@ -42,8 +50,8 @@ export type Creation<Options extends object> = DirectCreation &
 
 export interface DirectCreation {
 	files: CreatedFiles;
+	requests: CreatedRequest[];
 	scripts: CreatedScript[];
-	// TODO: Network calls
 }
 
 export interface IndirectCreation<Options extends object> {

--- a/packages/create/src/types/inputs.ts
+++ b/packages/create/src/types/inputs.ts
@@ -1,5 +1,5 @@
 import { TakeContext } from "./context.js";
-import { SystemRunner } from "./system.js";
+import { SystemFetchers, SystemRunner } from "./system.js";
 
 export type FileSystemReadFile = (filePath: string) => Promise<string>;
 
@@ -14,7 +14,7 @@ export type InputArgsFor<TypeofInput> =
 	TypeofInput extends Input<unknown, infer ArgsShape> ? ArgsShape : never;
 
 export interface InputContext extends TakeContext {
-	fetcher: typeof fetch;
+	fetchers: SystemFetchers;
 	fs: InputFileSystem;
 	runner: SystemRunner;
 }
@@ -25,6 +25,11 @@ export type InputContextFor<TypeofInput> =
 		: TypeofInput extends InputWithoutArgs<unknown>
 			? InputContext
 			: never;
+
+export interface InputContextWithArgs<Args extends object>
+	extends InputContext {
+	args: Args;
+}
 
 export interface InputContextWithArgs<Args extends object>
 	extends InputContext {

--- a/packages/create/src/types/system.ts
+++ b/packages/create/src/types/system.ts
@@ -1,4 +1,5 @@
 import { Result } from "execa";
+import { Octokit } from "octokit";
 
 import { TakeContext } from "./context.js";
 import { InputFileSystem } from "./inputs.js";
@@ -16,13 +17,18 @@ export interface FileSystemWriteFileOptions {
 }
 
 export interface NativeSystem {
-	fetcher: typeof fetch;
+	fetchers: SystemFetchers;
 	fs: WritingFileSystem;
 	runner: SystemRunner;
 }
 
 export interface SystemContext extends NativeSystem, TakeContext {
 	directory: string;
+}
+
+export interface SystemFetchers {
+	fetch: typeof fetch;
+	octokit: Octokit;
 }
 
 export type SystemRunner = (command: string) => Promise<Result>;

--- a/packages/create/src/utils/values.ts
+++ b/packages/create/src/utils/values.ts
@@ -1,3 +1,0 @@
-export function isNotUndefined<T>(value: T | undefined): value is T {
-	return value !== undefined;
-}

--- a/packages/site/astro.config.ts
+++ b/packages/site/astro.config.ts
@@ -25,9 +25,9 @@ export default defineConfig({
 							items: [
 								{ label: "Contexts", link: "engine/runtime/contexts" },
 								{ label: "Creations", link: "engine/runtime/creations" },
+								{ label: "Execution", link: "engine/runtime/execution" },
 								{ label: "Inputs", link: "engine/runtime/inputs" },
 								{ label: "Merging", link: "engine/runtime/merging" },
-								{ label: "Modes", link: "engine/runtime/modes" },
 							],
 							label: "Runtime",
 						},

--- a/packages/site/src/content/docs/engine/apis/runners.md
+++ b/packages/site/src/content/docs/engine/apis/runners.md
@@ -17,7 +17,7 @@ Each runner API takes in up to two arguments:
 1. The construct to be run
 2. An object with properties from the construct's context as well as [System contexts](../runtime/contexts#system-contexts) and:
    - `directory: string` (default: `'.'`): The root directory to write files to
-   - `mode`: What [runtime mode](../runtime/modes) to run in
+   - `mode`: What [runtime mode](../runtime/execution#modes) to run in
 
 :::note
 Runner APIs apply their generated objects to disk, as well as executing any network requests and shell commands.

--- a/packages/site/src/content/docs/engine/runtime/execution.md
+++ b/packages/site/src/content/docs/engine/runtime/execution.md
@@ -1,12 +1,20 @@
 ---
-description: "Different runtime modes the engine can be targeted to."
-title: Modes
+description: "How the engine produces Creations from Blocks at runtime."
+title: Execution
 ---
 
-:::danger
-The `create` engine is very early stage.
-Don't rely on it yet.
-:::
+The steps [`runPreset`](../apis/producers#producepreset) takes internally are:
+
+1. Create a queue of Blocks to be run, starting with all defined in the Preset
+2. For each Block in the queue:
+   1. Get the Creation from the Block, passing any current known Args
+   2. Store that Block's Creation
+   3. If a [runtime mode](#modes) is specified, additionally generate the approprate Block Creations
+   4. If the Block specified new addons for any other Blocks:
+      1. Add those Blocks to the queue of Blocks to re-run
+3. Merge all Block Creations together
+
+## Modes
 
 The `create` engine can be told to run in one the following "modes":
 
@@ -14,7 +22,7 @@ The `create` engine can be told to run in one the following "modes":
 - _(coming soon)_ `"migrate"`
 - `"new"`: Indicating the production is being used to create a new repository
 
-## `"new"`
+### `"new"`
 
 This mode creates a new repository on GitHub.
 As the production is run, including writing files on disk and running scripts, the `create` engine will:

--- a/packages/site/src/content/docs/engine/runtime/merging.md
+++ b/packages/site/src/content/docs/engine/runtime/merging.md
@@ -19,15 +19,22 @@ Blocks will be re-run whenever other Blocks signal new Addon data to them that t
 This allows Blocks to not need any explicit indication of what order to run in.
 
 Addons are merged by concatenating arrays and removing duplicate elements.
+Duplicates are detected by either `===` equality
 
 For example, given the following two Addons to be merged:
 
 ```ts
-[{ name: "First", steps: ["a", "b"] }];
+[
+	{ name: "First", steps: ["a", "b"] },
+	{ name: "Second", steps: ["c", "d"] },
+];
 ```
 
 ```ts
-[{ name: "Second", steps: ["c", "d"] }],
+[
+	{ name: "Second", steps: ["c", "d"] },
+	{ name: "Third", steps: ["e", "f"] },
+],
 ```
 
 The merged result would be:
@@ -36,6 +43,7 @@ The merged result would be:
 [
 	{ name: "First", steps: ["a", "b"] },
 	{ name: "Second", steps: ["c", "d"] },
+	{ name: "Third", steps: ["e", "f"] },
 ];
 ```
 

--- a/packages/site/src/content/docs/engine/runtime/merging.md
+++ b/packages/site/src/content/docs/engine/runtime/merging.md
@@ -18,29 +18,25 @@ At runtime, the `create` engine will often need to re-run Blocks continuously as
 Blocks will be re-run whenever other Blocks signal new Addon data to them that they haven't yet seen.
 This allows Blocks to not need any explicit indication of what order to run in.
 
-Addons are merged together as follows:
-
-- If two non-nullish properties have different types, an error is thrown
-- Arrays are concatenated together and have duplicate elements removed
-- Objects are spread together, with properties of keys recursively merged
+Addons are merged by concatenating arrays and removing duplicate elements.
 
 For example, given the following two Addons to be merged:
 
 ```ts
-{ info: { power: 9001 }, values: ["a", "b"] },
+[{ name: "First", steps: ["a", "b"] }];
 ```
 
 ```ts
-{ info: { recorded: true }, values: ["b", "c"] },
+[{ name: "Second", steps: ["c", "d"] }],
 ```
 
 The merged result would be:
 
 ```ts
-{
-   info: { power: 9001, recorded: true },
-   values: ["a", "b", "c"]
-}
+[
+	{ name: "First", steps: ["a", "b"] },
+	{ name: "Second", steps: ["c", "d"] },
+];
 ```
 
 ## Creations

--- a/packages/site/src/content/docs/engine/runtime/merging.md
+++ b/packages/site/src/content/docs/engine/runtime/merging.md
@@ -19,7 +19,7 @@ Blocks will be re-run whenever other Blocks signal new Addon data to them that t
 This allows Blocks to not need any explicit indication of what order to run in.
 
 Addons are merged by concatenating arrays and removing duplicate elements.
-Duplicates are detected by either `===` equality
+Duplicates are detected by [`hash-object`](https://www.npmjs.com/package/hash-object) object hashing.
 
 For example, given the following two Addons to be merged:
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,9 @@ importers:
       execa:
         specifier: ^9.5.2
         version: 9.5.2
+      octokit:
+        specifier: ^4.0.2
+        version: 4.0.2
       octokit-from-auth:
         specifier: ^0.3.0
         version: 0.3.0
@@ -119,6 +122,9 @@ importers:
       create:
         specifier: workspace:*
         version: link:../create
+      octokit:
+        specifier: ^4.0.2
+        version: 4.0.2
     devDependencies:
       zod:
         specifier: 3.24.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,9 @@ importers:
       execa:
         specifier: ^9.5.2
         version: 9.5.2
+      hash-object:
+        specifier: ^5.0.1
+        version: 5.0.1
       octokit:
         specifier: ^4.0.2
         version: 4.0.2
@@ -1849,6 +1852,10 @@ packages:
       supports-color:
         optional: true
 
+  decircular@0.1.1:
+    resolution: {integrity: sha512-V2Vy+QYSXdgxRPmOZKQWCDf1KQNTUP/Eqswv/3W20gz7+6GB1HTosNrWqK3PqstVpFw/Dd/cGTmXSTKPeOiGVg==}
+    engines: {node: '>=18'}
+
   decode-named-character-reference@1.0.2:
     resolution: {integrity: sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==}
 
@@ -2302,6 +2309,10 @@ packages:
     resolution: {integrity: sha512-Pq0h+hvsVm6dDEa8x82GnLSYHOzNDt7f0ddFa3FqcQlgzEiptPqL+XrOJNavjOzSYiYWIrgeVYYgGlLmnxwilQ==}
     engines: {node: '>=8'}
 
+  hash-object@5.0.1:
+    resolution: {integrity: sha512-iaRY4jYOow1caHkXW7wotYRjZDQk2nq4U7904anGJj8l4x1SLId+vuR8RpGoywZz9puD769hNFVFLFH9t+baJw==}
+    engines: {node: '>=18'}
+
   hast-util-embedded@3.0.0:
     resolution: {integrity: sha512-naH8sld4Pe2ep03qqULEtvYr7EjrLK2QHY8KJR6RJkTUjPGObe1vnx585uzem2hGra+s1q08DZZpfgDVYRbaXA==}
 
@@ -2487,6 +2498,10 @@ packages:
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+
+  is-obj@3.0.0:
+    resolution: {integrity: sha512-IlsXEHOjtKhpN8r/tRFj2nDyTmHvcfNeu/nrRIcXE17ROeatXchkojffa1SpdqW4cr/Fj6QkEf/Gn4zf6KKvEQ==}
+    engines: {node: '>=12'}
 
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
@@ -3413,6 +3428,10 @@ packages:
   smol-toml@1.3.1:
     resolution: {integrity: sha512-tEYNll18pPKHroYSmLLrksq233j021G0giwW7P3D24jC54pQ5W5BXMsQ/Mvw1OJCmEYDgY+lrzT+3nNUtoNfXQ==}
     engines: {node: '>= 18'}
+
+  sort-keys@5.1.0:
+    resolution: {integrity: sha512-aSbHV0DaBcr7u0PVHXzM6NbZNAtrr9sF6+Qfs9UUVG7Ll3jQ6hHi8F/xqIIcn2rvIVbr0v/2zyjSdwSV47AgLQ==}
+    engines: {node: '>=12'}
 
   sort-object-keys@1.1.3:
     resolution: {integrity: sha512-855pvK+VkU7PaKYPc+Jjnmt4EzejQHyhhF33q31qG8x7maDzkeFhAAThdCYay11CISO+qAMwjOBP+fPZe0IPyg==}
@@ -5791,6 +5810,8 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decircular@0.1.1: {}
+
   decode-named-character-reference@1.0.2:
     dependencies:
       character-entities: 2.0.2
@@ -6333,6 +6354,13 @@ snapshots:
 
   has-own-prop@2.0.0: {}
 
+  hash-object@5.0.1:
+    dependencies:
+      decircular: 0.1.1
+      is-obj: 3.0.0
+      sort-keys: 5.1.0
+      type-fest: 4.30.2
+
   hast-util-embedded@3.0.0:
     dependencies:
       '@types/hast': 3.0.4
@@ -6602,6 +6630,8 @@ snapshots:
       is-docker: 3.0.0
 
   is-number@7.0.0: {}
+
+  is-obj@3.0.0: {}
 
   is-plain-obj@4.1.0: {}
 
@@ -7997,6 +8027,10 @@ snapshots:
       is-fullwidth-code-point: 5.0.0
 
   smol-toml@1.3.1: {}
+
+  sort-keys@5.1.0:
+    dependencies:
+      is-plain-obj: 4.1.0
 
   sort-object-keys@1.1.3: {}
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #23
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds in the concept of _requests_ to Creations. Requests are each an object with an `id: string` and an asynchronous `send` method.

Overhauls Addons merging, now that the initial set of Creations types is known. Uses [`hash-object`](https://www.npmjs.com/package/hash-object) for deduplication of array elements.

Note that this is the first Creation form that isn't directly serializable. _Files_ and _scripts_ can all be made JSON; _requests_ now introduce functions. I'd been hoping to keep everything serializable - but being able to instead get nice type completion with using Octokit APIs is just more useful.

If someone wants serializable requests in the future, I suppose they could file a feature request asking for the JSON-like equivalent of this. Something like:

```ts
{
  "fetcher": "octokit",
  "method": ["rest", "repos", "update"],
  "send": {
    allow_auto_merge: true,
    // ...
  }
}
```

...where fancy TypeScript types determine the `send` data to be `Parameters<typeof octokit.rest.repos.update>[0]`. That's a lot more work. Perhaps a future improvement.  

I also don't love that explicit `id` in there. Previous Creations are auto-mergable without them; this one is manual. I suppose that's also tied in with it not being serializable. Perhaps a future improvement.