### PR TITLE
fix: factor mode into testBlock

### DIFF
--- a/packages/create-testers/src/testBlock.test.ts
+++ b/packages/create-testers/src/testBlock.test.ts
@@ -41,19 +41,22 @@ describe("testBlock", () => {
 			produce({ addons }) {
 				return {
 					files: {
-						"value.txt": addons.value,
+						"value.txt": addons.value ?? "default",
 					},
 				};
 			},
 		});
 
-		it("throws an error when addons isn't provided and a block uses addons", () => {
-			expect(
-				// @ts-expect-error -- Intentionally not allowed by types.
-				() => testBlock(blockUsingAddons, {}),
-			).toThrowErrorMatchingInlineSnapshot(
-				`[Error: Context property 'addons' was used by the Block but not provided.]`,
-			);
+		it("does not throws an error when addons isn't provided and a block uses addons", () => {
+			const actual = testBlock(blockUsingAddons, {});
+
+			expect(actual).toMatchInlineSnapshot(`
+				{
+				  "files": {
+				    "value.txt": "default",
+				  },
+				}
+			`);
 		});
 
 		it("passes addons to the block when provided", () => {

--- a/packages/create-testers/src/testBlock.ts
+++ b/packages/create-testers/src/testBlock.ts
@@ -1,28 +1,29 @@
-import { BlockWithAddons, BlockWithoutAddons, Creation } from "create";
+import {
+	BlockProductionSettingsWithAddons,
+	BlockWithAddons,
+	BlockWithoutAddons,
+	Creation,
+	produceBlock,
+} from "create";
+import { ProductionMode } from "create/lib/modes/types.js";
 
-import { createFailingObject, failingFunction } from "./utils.js";
+import { createFailingObject } from "./utils.js";
 
 export interface BlockContextSettingsWithOptionalAddons<
 	Addons extends object,
 	Options extends object,
 > extends BlockContextSettingsWithoutAddons<Options> {
-	addons?: Addons;
+	addons?: Partial<Addons>;
 }
 
 export interface BlockContextSettingsWithoutAddons<Options extends object> {
+	mode?: ProductionMode;
 	options?: Options;
-}
-
-export interface BlockContextSettingsWithRequiredAddons<
-	Addons extends object,
-	Options extends object,
-> extends BlockContextSettingsWithoutAddons<Options> {
-	addons: Addons;
 }
 
 export function testBlock<Addons extends object, Options extends object>(
 	block: BlockWithAddons<Addons, Options>,
-	settings: BlockContextSettingsWithRequiredAddons<Addons, Options>,
+	settings: BlockContextSettingsWithOptionalAddons<Addons, Options>,
 ): Partial<Creation<Options>>;
 export function testBlock<Options extends object>(
 	block: BlockWithoutAddons<Options>,
@@ -32,11 +33,12 @@ export function testBlock<Addons extends object, Options extends object>(
 	block: BlockWithAddons<Addons, Options> | BlockWithoutAddons<Options>,
 	settings: BlockContextSettingsWithOptionalAddons<Addons, Options> = {},
 ): Partial<Creation<Options>> {
-	return block.produce({
-		get addons() {
-			return failingFunction("addons", "the Block");
-		},
-		options: createFailingObject("options", "the Block") as Options,
-		...settings,
-	});
+	return produceBlock(
+		block as BlockWithAddons<Addons, Options>,
+		{
+			addons: {},
+			options: createFailingObject("options", "the Block") as Options,
+			...settings,
+		} as BlockProductionSettingsWithAddons<Addons, Options>,
+	);
 }

--- a/packages/create-testers/src/utils.ts
+++ b/packages/create-testers/src/utils.ts
@@ -11,7 +11,7 @@ export function createFailingObject(label: string, user: string) {
 	);
 }
 
-export function failingFunction(label: string, user: string): never {
+function failingFunction(label: string, user: string): never {
 	throw new Error(
 		`Context property '${label}' was used by ${user} but not provided.`,
 	);

--- a/packages/create/src/mergers/applyMerger.test.ts
+++ b/packages/create/src/mergers/applyMerger.test.ts
@@ -2,13 +2,11 @@ import { describe, expect, it } from "vitest";
 
 import { applyMerger } from "./applyMerger.js";
 
-const fallback = "c";
-
 describe("applyMerger", () => {
 	it("returns second when first is undefined", () => {
 		const second = "b";
 
-		const actual = applyMerger(undefined, second, (a, b) => a + b, fallback);
+		const actual = applyMerger(undefined, second, (a, b) => a + b);
 
 		expect(actual).toBe(second);
 	});
@@ -16,22 +14,14 @@ describe("applyMerger", () => {
 	it("returns first when second is undefined", () => {
 		const first = "a";
 
-		const actual = applyMerger(first, undefined, (a, b) => a + b, fallback);
+		const actual = applyMerger(first, undefined, (a, b) => a + b);
 
 		expect(actual).toBe(first);
 	});
 
-	it("returns fallback when first and second are undefined", () => {
-		const actual = applyMerger(undefined, undefined, (a, b) => a + b, fallback);
+	it("returns undefined when first and second are undefined", () => {
+		const actual = applyMerger<string>(undefined, undefined, (a, b) => a + b);
 
-		expect(actual).toBe(fallback);
-	});
-	it("returns the merger when first and second are defined", () => {
-		const first = "a";
-		const second = "b";
-
-		const actual = applyMerger(first, second, (a, b) => a + b, fallback);
-
-		expect(actual).toBe("ab");
+		expect(actual).toBe(undefined);
 	});
 });

--- a/packages/create/src/mergers/applyMerger.ts
+++ b/packages/create/src/mergers/applyMerger.ts
@@ -2,10 +2,9 @@ export function applyMerger<T>(
 	first: T | undefined,
 	second: T | undefined,
 	merger: (first: T, second: T) => T,
-	fallback: T,
 ) {
 	if (first == null || second == null) {
-		return second ?? first ?? fallback;
+		return second ?? first ?? undefined;
 	}
 
 	return merger(first, second);

--- a/packages/create/src/mergers/mergeCreations.ts
+++ b/packages/create/src/mergers/mergeCreations.ts
@@ -8,11 +8,22 @@ import { mergeScripts } from "./mergeScripts.js";
 export function mergeCreations<Options extends object>(
 	first: Partial<Creation<Options>>,
 	second: Partial<Creation<Options>>,
-): Creation<Options> {
-	return {
-		addons: applyMerger(first.addons, second.addons, mergeAddons, []),
-		files: applyMerger(first.files, second.files, mergeFileCreations, {}),
-		requests: applyMerger(first.requests, second.requests, mergeRequests, []),
-		scripts: applyMerger(first.scripts, second.scripts, mergeScripts, []),
-	};
+): Partial<Creation<Options>> {
+	return removeEmptyProperties({
+		addons: applyMerger(first.addons, second.addons, mergeAddons),
+		files: applyMerger(first.files, second.files, mergeFileCreations),
+		requests: applyMerger(first.requests, second.requests, mergeRequests),
+		scripts: applyMerger(first.scripts, second.scripts, mergeScripts),
+	});
+}
+
+function removeEmptyProperties<T extends object>(value: T): T {
+	for (const k in value) {
+		if (value[k] === undefined) {
+			// eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+			delete value[k];
+		}
+	}
+
+	return value;
 }

--- a/packages/create/src/producers/executePresetBlocks.test.ts
+++ b/packages/create/src/producers/executePresetBlocks.test.ts
@@ -47,12 +47,9 @@ describe("runPreset", () => {
 		);
 
 		expect(result).toEqual({
-			addons: [],
 			files: {
 				"README.md": "Hello, world!",
 			},
-			requests: [],
-			scripts: [],
 		});
 	});
 
@@ -91,12 +88,9 @@ describe("runPreset", () => {
 			);
 
 			expect(result).toEqual({
-				addons: [],
 				files: {
 					"README.md": "Hello, world!",
 				},
-				requests: [],
-				scripts: [],
 			});
 		});
 
@@ -109,13 +103,10 @@ describe("runPreset", () => {
 			);
 
 			expect(result).toEqual({
-				addons: [],
 				files: {
 					"data.txt": "Hello, world!",
 					"README.md": "Hello, world!",
 				},
-				requests: [],
-				scripts: [],
 			});
 		});
 	});

--- a/packages/create/src/producers/producePreset.ts
+++ b/packages/create/src/producers/producePreset.ts
@@ -95,5 +95,14 @@ export async function producePreset<OptionsShape extends AnyShape>(
 		mode,
 	);
 
-	return { creation, options: fullOptions };
+	return {
+		creation: {
+			addons: [],
+			files: {},
+			requests: [],
+			scripts: [],
+			...creation,
+		},
+		options: fullOptions,
+	};
 }

--- a/packages/site/src/content/docs/engine/apis/testers.md
+++ b/packages/site/src/content/docs/engine/apis/testers.md
@@ -146,7 +146,6 @@ Both [Direct Creations](../runtime/creations#direct-creations) and [Indirect Cre
 `settings` and all its properties are optional.
 However, some properties will cause `testBlock` to throw an error if they're not provided and the Block attempts to use them:
 
-- [`addons`](#testblock-addons): throws an error if accessed at all
 - [`options`](#testblock-options): each property throws an error if accessed at all
 
 ### `addons` {#testblock-addons}

--- a/packages/site/src/content/docs/engine/runtime/execution.md
+++ b/packages/site/src/content/docs/engine/runtime/execution.md
@@ -7,7 +7,7 @@ The steps [`runPreset`](../apis/producers#producepreset) takes internally are:
 
 1. Create a queue of Blocks to be run, starting with all defined in the Preset
 2. For each Block in the queue:
-   1. Get the Creation from the Block, passing any current known Args
+   1. Get the Creation from the Block, passing any current known Addons
    2. Store that Block's Creation
    3. If a [runtime mode](#modes) is specified, additionally generate the approprate Block Creations
    4. If the Block specified new addons for any other Blocks:


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #66
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Shuffles around APIs so that `produceBlock` is reused inside both `testBlock` and `executePresetBlocks` <- `runPreset`.

Fixes `testBlock` to also allow not providing `addons`. They used to be mandatory, but are now enforced to all be optional. No need to enforce passing `{}` for them.

Also trims down `mergeCreations` to not include properties with `undefined` values. This simplifies test snapshots a good bit.

💖 