### PR TITLE
feat: add mode: 'migrate', and rename 'new' to 'initialize'

### DIFF
--- a/packages/create/src/modes/types.ts
+++ b/packages/create/src/modes/types.ts
@@ -3,6 +3,4 @@ export interface CreationOptions {
 	repository: string;
 }
 
-// TODO(#44): Add "initialize"
-// TODO(#45): Add "migrate"
-export type ProductionMode = "new";
+export type ProductionMode = "initialize" | "migrate";

--- a/packages/create/src/producers/executePresetBlocks.test.ts
+++ b/packages/create/src/producers/executePresetBlocks.test.ts
@@ -53,7 +53,7 @@ describe("runPreset", () => {
 		});
 	});
 
-	describe("initialize", () => {
+	describe("modes", () => {
 		const block = base.createBlock({
 			about: {
 				name: "Example Block",
@@ -63,6 +63,11 @@ describe("runPreset", () => {
 					files: {
 						"data.txt": options.value,
 					},
+				};
+			},
+			migrate() {
+				return {
+					scripts: ["rm old.txt"],
 				};
 			},
 			produce({ options }) {
@@ -79,7 +84,7 @@ describe("runPreset", () => {
 			blocks: [block],
 		});
 
-		it("does not augment creations with a Block's initialize() when mode is undefined", () => {
+		it("does not augment creations with a Block's initialize() or migrate() when mode is undefined", () => {
 			const result = executePresetBlocks(
 				preset,
 				{ value: "Hello, world!" },
@@ -94,12 +99,12 @@ describe("runPreset", () => {
 			});
 		});
 
-		it("augments creations with a Block's initialize() when mode is 'new'", () => {
+		it("augments creations with a Block's initialize() when mode is 'initialize'", () => {
 			const result = executePresetBlocks(
 				preset,
 				{ value: "Hello, world!" },
 				context,
-				"new",
+				"initialize",
 			);
 
 			expect(result).toEqual({
@@ -107,6 +112,22 @@ describe("runPreset", () => {
 					"data.txt": "Hello, world!",
 					"README.md": "Hello, world!",
 				},
+			});
+		});
+
+		it("augments creations with a Block's migrate() when mode is 'migrate'", () => {
+			const result = executePresetBlocks(
+				preset,
+				{ value: "Hello, world!" },
+				context,
+				"migrate",
+			);
+
+			expect(result).toEqual({
+				files: {
+					"README.md": "Hello, world!",
+				},
+				scripts: ["rm old.txt"],
 			});
 		});
 	});

--- a/packages/create/src/producers/produceBlock.ts
+++ b/packages/create/src/producers/produceBlock.ts
@@ -45,10 +45,11 @@ export function produceBlock<Addons extends object, Options extends object>(
 
 	// From engine/runtime/execution.md:
 	// 2.2. If a mode is specified, additionally generate the appropriate Block Creations
-	if (settings.mode === "new" && block.initialize) {
+	const augment = settings.mode && block[settings.mode];
+	if (augment) {
 		creation = mergeCreations(
 			creation,
-			block.initialize(settings as BlockContextWithAddons<Addons, Options>),
+			augment(settings as BlockContextWithAddons<Addons, Options>),
 		);
 	}
 

--- a/packages/create/src/runners/runPreset.ts
+++ b/packages/create/src/runners/runPreset.ts
@@ -56,7 +56,7 @@ export async function runPreset<OptionsShape extends AnyShape>(
 		} as FullPresetRunSettings<OptionsShape>,
 	);
 
-	if (settings.mode === "new") {
+	if (settings.mode === "initialize") {
 		// TODO: Hardcode owner and repository existing in options?
 		await createRepositoryOnGitHub(
 			options as unknown as CreationOptions,
@@ -67,7 +67,7 @@ export async function runPreset<OptionsShape extends AnyShape>(
 
 	await applyCreation(creation, system);
 
-	if (settings.mode === "new") {
+	if (settings.mode === "initialize") {
 		await createTrackingBranches(
 			options as unknown as CreationOptions,
 			system.runner,

--- a/packages/create/src/types/blocks.ts
+++ b/packages/create/src/types/blocks.ts
@@ -9,6 +9,17 @@ export type Block<
 	? BlockWithAddons<Addons, Options>
 	: BlockWithoutAddons<Options>;
 
+export type BlockAugmentWithAddons<
+	Addons extends object,
+	Options extends object,
+> = (
+	context: BlockContextWithAddons<Addons, Options>,
+) => Partial<DirectCreation>;
+
+export type BlockAugmentWithoutAddons<Options extends object> = (
+	context: BlockContextWithoutAddons<Options>,
+) => Partial<DirectCreation>;
+
 export interface BlockBase {
 	about?: AboutBase;
 }
@@ -60,7 +71,8 @@ export interface BlockDefinitionWithAddons<
 	Options extends object,
 > extends BlockDefinitionBase {
 	addons: AddonsShape;
-	initialize?: BlockInitializeWithAddons<InferredObject<AddonsShape>, Options>;
+	initialize?: BlockAugmentWithAddons<InferredObject<AddonsShape>, Options>;
+	migrate?: BlockAugmentWithAddons<InferredObject<AddonsShape>, Options>;
 	produce: BlockDefinitionProducerWithAddons<
 		InferredObject<AddonsShape>,
 		Options
@@ -69,20 +81,10 @@ export interface BlockDefinitionWithAddons<
 
 export interface BlockDefinitionWithoutAddons<Options extends object>
 	extends BlockDefinitionBase {
-	initialize?: BlockInitializeWithoutAddons<Options>;
+	initialize?: BlockAugmentWithoutAddons<Options>;
+	migrate?: BlockAugmentWithoutAddons<Options>;
 	produce: BlockDefinitionProducerWithoutAddons<Options>;
 }
-
-export type BlockInitializeWithAddons<
-	Addons extends object,
-	Options extends object,
-> = (
-	context: BlockContextWithAddons<Addons, Options>,
-) => Partial<DirectCreation>;
-
-export type BlockInitializeWithoutAddons<Options extends object> = (
-	context: BlockContextWithoutAddons<Options>,
-) => Partial<DirectCreation>;
 
 export type BlockProducerWithAddons<
 	Addons extends object,
@@ -97,12 +99,14 @@ export type BlockProducerWithoutAddons<Options extends object> = (
 
 export interface BlockWithAddons<Addons extends object, Options extends object>
 	extends BlockBase {
-	initialize?: BlockInitializeWithAddons<Addons, Options>;
+	initialize?: BlockAugmentWithAddons<Addons, Options>;
+	migrate?: BlockAugmentWithAddons<Addons, Options>;
 	produce: BlockProducerWithAddons<Addons, Options>;
 	(addons: Partial<Addons>): CreatedBlockAddons<Addons, Options>;
 }
 
 export interface BlockWithoutAddons<Options extends object> extends BlockBase {
-	initialize?: BlockInitializeWithoutAddons<Options>;
+	initialize?: BlockAugmentWithoutAddons<Options>;
+	migrate?: BlockAugmentWithoutAddons<Options>;
 	produce: BlockProducerWithoutAddons<Options>;
 }

--- a/packages/site/src/content/docs/engine/apis/runners.md
+++ b/packages/site/src/content/docs/engine/apis/runners.md
@@ -57,7 +57,7 @@ import { runBlock } from "create";
 import { presetWithReadme } from "./presetWithReadme.js";
 
 await runPreset(presetWithReadme, {
-	mode: "new",
+	mode: "initialize",
 	owner: "JoshuaKGoldberg",
 	repository: "example-new-repository",
 });

--- a/packages/site/src/content/docs/engine/runtime/execution.md
+++ b/packages/site/src/content/docs/engine/runtime/execution.md
@@ -16,13 +16,12 @@ The steps [`runPreset`](../apis/producers#producepreset) takes internally are:
 
 ## Modes
 
-The `create` engine can be told to run in one the following "modes":
+The `create` engine can optionally be told to run in one the following "modes":
 
-- _(coming soon)_ `"initialize"`
-- _(coming soon)_ `"migrate"`
-- `"new"`: Indicating the production is being used to create a new repository
+- `"initialize"`: Indicating the production is being used to create a new repository
+- `"migrate"`: Indicating the production is migrating an existing repository
 
-### `"new"`
+### `"initialize"`
 
 This mode creates a new repository on GitHub.
 As the production is run, including writing files on disk and running scripts, the `create` engine will:
@@ -31,3 +30,9 @@ As the production is run, including writing files on disk and running scripts, t
    - If the Preset's Base defines a [`template`](../apis/creators#createbase-template), the repository will include a _generated from_ notice pointing to that template repository
 2. Add that new repository as the `origin` remote
 3. Force-push a single commit with the new repository contents to that origin
+
+### `"migrate"`
+
+This mode migrates an existing repository onto the provided template.
+As the production is run, the `create` engine will add in additional creations.
+This typically includes scripts that delete files from known no-longer-used pieces of tooling.


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #44, fixes #45
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

I'd originally ideated having three modes the way CTA does: `"create"`, `"initialize"`, and `"migrate"`. But CTA's `"initialize"` is really an overlap of the other two: it's just that the repo happens to be newly created from a template.

So now there are just two execution / production modes in `create`:

- `"initialize"`: Indicating the production is being used to create a new repository
- `"migrate"`: Indicating the production is migrating an existing repository

The optional Block methods for the the two have those names and the same signature. They produce the same kind of outputs as before. `migrate()`s typically produce `scripts` that `rm` old files. That's roughly the extent of what CTA was doing that I can tell.

Marks #44 and #45 as resolved because they're now understood by the core engine. CLI work that creates new repositories as necessary will come later, perhaps with new issue(s).

💖 