### PR TITLE
feat: allow addons in config files

### DIFF
--- a/packages/create/src/cli/migrate/runModeMigrate.ts
+++ b/packages/create/src/cli/migrate/runModeMigrate.ts
@@ -1,5 +1,4 @@
 import * as prompts from "@clack/prompts";
-import path from "node:path";
 
 import { runPreset } from "../../runners/runPreset.js";
 import { createSystemContextWithAuth } from "../../system/createSystemContextWithAuth.js";

--- a/packages/create/src/producers/executePresetBlocks.test.ts
+++ b/packages/create/src/producers/executePresetBlocks.test.ts
@@ -5,7 +5,7 @@ import { createBase } from "../creators/createBase.js";
 import { createSystemFetchers } from "../system/createSystemFetchers.js";
 import { executePresetBlocks } from "./executePresetBlocks.js";
 
-const context = {
+const presetContext = {
 	directory: ".",
 	display: {
 		item: vi.fn(),
@@ -43,16 +43,51 @@ describe("runPreset", () => {
 			blocks: [block],
 		});
 
-		const result = executePresetBlocks(
+		const result = executePresetBlocks({
+			options: { value: "Hello, world!" },
 			preset,
-			{ value: "Hello, world!" },
-			context,
-			undefined,
-		);
+			presetContext,
+		});
 
 		expect(result).toEqual({
 			files: {
 				"README.md": "Hello, world!",
+			},
+		});
+	});
+
+	it("adds addons when provided", () => {
+		const block = base.createBlock({
+			about: {
+				name: "Example Block",
+			},
+			addons: {
+				extra: z.string().default(""),
+			},
+			produce({ addons, options }) {
+				return {
+					files: { "README.md": [options.value, addons.extra].join("\n") },
+				};
+			},
+		});
+
+		const preset = base.createPreset({
+			about: {
+				name: "Example Preset",
+			},
+			blocks: [block],
+		});
+
+		const result = executePresetBlocks({
+			addons: [block({ extra: "line" })],
+			options: { value: "Hello, world!" },
+			preset,
+			presetContext,
+		});
+
+		expect(result).toEqual({
+			files: {
+				"README.md": "Hello, world!\nline",
 			},
 		});
 	});
@@ -89,12 +124,11 @@ describe("runPreset", () => {
 		});
 
 		it("does not augment creations with a Block's initialize() or migrate() when mode is undefined", () => {
-			const result = executePresetBlocks(
+			const result = executePresetBlocks({
+				options: { value: "Hello, world!" },
 				preset,
-				{ value: "Hello, world!" },
-				context,
-				undefined,
-			);
+				presetContext,
+			});
 
 			expect(result).toEqual({
 				files: {
@@ -104,12 +138,12 @@ describe("runPreset", () => {
 		});
 
 		it("augments creations with a Block's initialize() when mode is 'initialize'", () => {
-			const result = executePresetBlocks(
+			const result = executePresetBlocks({
+				mode: "initialize",
+				options: { value: "Hello, world!" },
 				preset,
-				{ value: "Hello, world!" },
-				context,
-				"initialize",
-			);
+				presetContext,
+			});
 
 			expect(result).toEqual({
 				files: {
@@ -120,12 +154,12 @@ describe("runPreset", () => {
 		});
 
 		it("augments creations with a Block's migrate() when mode is 'migrate'", () => {
-			const result = executePresetBlocks(
+			const result = executePresetBlocks({
+				mode: "migrate",
+				options: { value: "Hello, world!" },
 				preset,
-				{ value: "Hello, world!" },
-				context,
-				"migrate",
-			);
+				presetContext,
+			});
 
 			expect(result).toEqual({
 				files: {

--- a/packages/create/src/producers/executePresetBlocks.ts
+++ b/packages/create/src/producers/executePresetBlocks.ts
@@ -5,18 +5,29 @@ import {
 import { mergeCreations } from "../mergers/mergeCreations.js";
 import { AnyShape, InferredObject } from "../options.js";
 import { Block, BlockWithAddons } from "../types/blocks.js";
-import { Creation } from "../types/creations.js";
+import { CreatedBlockAddons, Creation } from "../types/creations.js";
 import { ProductionMode } from "../types/modes.js";
 import { Preset } from "../types/presets.js";
 import { SystemContext } from "../types/system.js";
 import { produceBlock } from "./produceBlock.js";
 
-export function executePresetBlocks<OptionsShape extends AnyShape>(
-	preset: Preset<OptionsShape>,
-	options: InferredObject<OptionsShape>,
-	presetContext: SystemContext,
-	mode: ProductionMode | undefined,
-) {
+export interface ExecutePresetBlocksSettings<OptionsShape extends AnyShape> {
+	// TODO: I don't know what to put here instead of object...
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	addons?: CreatedBlockAddons<any, InferredObject<OptionsShape>>[];
+	mode?: ProductionMode;
+	options: InferredObject<OptionsShape>;
+	preset: Preset<OptionsShape>;
+	presetContext: SystemContext;
+}
+
+export function executePresetBlocks<OptionsShape extends AnyShape>({
+	addons,
+	mode,
+	options,
+	preset,
+	presetContext,
+}: ExecutePresetBlocksSettings<OptionsShape>) {
 	type Options = InferredObject<OptionsShape>;
 
 	// From engine/runtime/execution.md:
@@ -25,7 +36,7 @@ export function executePresetBlocks<OptionsShape extends AnyShape>(
 	const blockProductions = new Map<
 		Block<object | undefined, Options>,
 		BlockProduction<object, Options>
-	>();
+	>(addons?.map((addon) => [addon.block, { addons: addon.addons as object }]));
 
 	// 1. Create a queue of Blocks to be run, starting with all defined in the Preset
 	const blocksToBeRun = new Set(preset.blocks);

--- a/packages/create/src/producers/producePreset.ts
+++ b/packages/create/src/producers/producePreset.ts
@@ -1,6 +1,6 @@
 import { AnyShape, InferredObject } from "../options.js";
 import { createSystemContextWithAuth } from "../system/createSystemContextWithAuth.js";
-import { Creation } from "../types/creations.js";
+import { CreatedBlockAddons, Creation } from "../types/creations.js";
 import { ProductionMode } from "../types/modes.js";
 import { Preset } from "../types/presets.js";
 import { NativeSystem } from "../types/system.js";
@@ -9,6 +9,7 @@ import { executePresetBlocks } from "./executePresetBlocks.js";
 export interface PresetProductionSettings<OptionsShape extends AnyShape>
 	extends Partial<NativeSystem>,
 		ProductionSettingsBase {
+	addons?: CreatedBlockAddons<object, InferredObject<OptionsShape>>[];
 	options: InferredObject<OptionsShape>;
 }
 
@@ -20,6 +21,7 @@ export interface ProductionSettingsBase {
 export async function producePreset<OptionsShape extends AnyShape>(
 	preset: Preset<OptionsShape>,
 	{
+		addons,
 		directory = ".",
 		mode,
 		options,
@@ -31,12 +33,13 @@ export async function producePreset<OptionsShape extends AnyShape>(
 		...providedSystem,
 	});
 
-	const creation = executePresetBlocks(
-		preset,
-		options,
-		{ ...system, directory },
+	const creation = executePresetBlocks({
+		addons,
 		mode,
-	);
+		options,
+		preset,
+		presetContext: { ...system, directory },
+	});
 
 	return {
 		addons: [],

--- a/packages/create/src/runners/runPreset.ts
+++ b/packages/create/src/runners/runPreset.ts
@@ -3,19 +3,15 @@ import fs from "node:fs/promises";
 import { AnyShape, InferredObject } from "../options.js";
 import { producePreset } from "../producers/producePreset.js";
 import { createSystemContextWithAuth } from "../system/createSystemContextWithAuth.js";
-import { Creation } from "../types/creations.js";
+import { CreatedBlockAddons, Creation } from "../types/creations.js";
 import { ProductionMode } from "../types/modes.js";
 import { Preset } from "../types/presets.js";
 import { NativeSystem } from "../types/system.js";
 import { applyCreation } from "./applyCreation.js";
 
-export interface AugmentingPresetRunSettings<OptionsShape extends AnyShape>
-	extends RunSettingsBase {
-	options?: Partial<InferredObject<OptionsShape>>;
-}
-
 export interface PresetRunSettings<OptionsShape extends AnyShape>
 	extends RunSettingsBase {
+	addons?: CreatedBlockAddons<object, InferredObject<OptionsShape>>[];
 	options: InferredObject<OptionsShape>;
 }
 

--- a/packages/site/src/content/docs/configuration.md
+++ b/packages/site/src/content/docs/configuration.md
@@ -44,10 +44,6 @@ The customizations that can be passed to `createConfig` are a superset of what y
 
 ### `addons`
 
-:::danger
-Addons in config files have not yet been implemented.
-:::
-
 Any [Addons](./engine/concepts/blocks#addons) to be passed to the [Blocks](./engines/concepts/blocks) that come with the Preset.
 These will be [merged](./engine/runtime/merging) in with Addons provided by other Blocks.
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #88
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Passes `addons` through to `executePresetBlocks`, which conveniently already had a tracker for "previous" Addons per-Block.

💖 