### PR TITLE
feat: add --exclude-* CLI flags

### DIFF
--- a/packages/create/src/cli/migrate/runModeMigrate.test.ts
+++ b/packages/create/src/cli/migrate/runModeMigrate.test.ts
@@ -63,6 +63,14 @@ vi.mock("../createInitialCommit.js", () => ({
 	},
 }));
 
+const mockApplyArgsToSettings = vi.fn();
+
+vi.mock("../parsers/applyArgsToSettings", () => ({
+	get applyArgsToSettings() {
+		return mockApplyArgsToSettings;
+	},
+}));
+
 const mockClearTemplateFiles = vi.fn();
 
 vi.mock("./clearTemplateFiles.js", () => ({
@@ -152,6 +160,21 @@ describe("runModeMigrate", () => {
 		expect(actual).toEqual({
 			status: CLIStatus.Cancelled,
 		});
+	});
+
+	it("returns the error when applyArgsToSettings returns an error", async () => {
+		const message = "Oh no!";
+
+		mockParseMigrationSource.mockReturnValueOnce({
+			load: () => Promise.resolve({ preset }),
+		});
+		mockPromptForBaseOptions.mockResolvedValueOnce({});
+		mockGetForkedTemplateLocator.mockResolvedValueOnce(undefined);
+		mockApplyArgsToSettings.mockReturnValueOnce(new Error(message));
+
+		const actual = await runModeMigrate({ args: [], configFile: undefined });
+
+		expect(actual).toEqual({ outro: message, status: CLIStatus.Error });
 	});
 
 	it("doesn't clear the existing repository when no forked template locator is available", async () => {

--- a/packages/create/src/cli/migrate/runModeMigrate.ts
+++ b/packages/create/src/cli/migrate/runModeMigrate.ts
@@ -8,6 +8,7 @@ import { createInitialCommit } from "../createInitialCommit.js";
 import { createClackDisplay } from "../display/createClackDisplay.js";
 import { runSpinnerTask } from "../display/runSpinnerTask.js";
 import { findPositionalFrom } from "../findPositionalFrom.js";
+import { applyArgsToSettings } from "../parsers/applyArgsToSettings.js";
 import { parseZodArgs } from "../parsers/parseZodArgs.js";
 import { promptForBaseOptions } from "../prompts/promptForBaseOptions.js";
 import { CLIStatus } from "../status.js";
@@ -94,13 +95,18 @@ export async function runModeMigrate({
 		return { status: CLIStatus.Cancelled };
 	}
 
+	const mergedSettings = applyArgsToSettings(args, preset, settings);
+	if (mergedSettings instanceof Error) {
+		return { outro: mergedSettings.message, status: CLIStatus.Error };
+	}
+
 	await runSpinnerTask(
 		display,
 		`Running the ${preset.about.name} preset`,
 		`Ran the ${preset.about.name} preset`,
 		async () => {
 			await runPreset(preset, {
-				...settings,
+				...mergedSettings,
 				...system,
 				directory,
 				mode: "migrate",

--- a/packages/create/src/cli/parsers/applyArgsToSettings.test.ts
+++ b/packages/create/src/cli/parsers/applyArgsToSettings.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createBase } from "../../creators/createBase.js";
+import { applyArgsToSettings } from "./applyArgsToSettings.js";
+
+const base = createBase({
+	options: {},
+});
+
+const blockA = base.createBlock({
+	about: { name: "A" },
+	produce: vi.fn(),
+});
+
+const blockB = base.createBlock({
+	about: { name: "B" },
+	produce: vi.fn(),
+});
+
+const blockC = base.createBlock({
+	about: { name: "C" },
+	produce: vi.fn(),
+});
+
+const blockD = base.createBlock({
+	about: { name: "D" },
+	produce: vi.fn(),
+});
+
+const preset = base.createPreset({
+	about: { name: "Preset " },
+	blocks: [blockA, blockB, blockC],
+});
+
+describe("applyArgsToSettings", () => {
+	it("returns blank settings when args don't exclude Blocks and settings is undefined", () => {
+		const actual = applyArgsToSettings([], preset);
+
+		expect(actual).toEqual({});
+	});
+
+	it("returns the same settings when args don't exclude Blocks and settings is provided", () => {
+		const settings = {
+			blocks: { add: [blockD], exclude: [] },
+			options: {
+				value: 123,
+			},
+		};
+		const actual = applyArgsToSettings(["--other"], preset, settings);
+
+		expect(actual).toBe(settings);
+	});
+
+	it("returns an error when an unknown Block is excluded", () => {
+		const settings = {
+			blocks: { add: [blockD], exclude: [] },
+			options: {
+				value: 123,
+			},
+		};
+		const actual = applyArgsToSettings(["--exclude-other"], preset, settings);
+
+		expect(actual).toEqual(
+			new Error(
+				"Block exclusion doesn't match any preset block: '--exclude-other'.",
+			),
+		);
+	});
+
+	it("returns settings with the Block excluded when one of the Preset's Blocks is excluded", () => {
+		const settings = {
+			blocks: { add: [blockD], exclude: [blockA] },
+			options: {
+				value: 123,
+			},
+		};
+		const actual = applyArgsToSettings(["--exclude-b"], preset, settings);
+
+		expect(actual).toEqual({
+			blocks: {
+				add: [blockD],
+				exclude: [blockA, blockB],
+			},
+			options: {
+				value: 123,
+			},
+		});
+	});
+});

--- a/packages/create/src/cli/parsers/applyArgsToSettings.ts
+++ b/packages/create/src/cli/parsers/applyArgsToSettings.ts
@@ -1,0 +1,47 @@
+import { CreateConfigSettings } from "../../config/types.js";
+import { AnyShape, InferredObject } from "../../options.js";
+import { Preset } from "../../types/presets.js";
+
+export function applyArgsToSettings<OptionsShape extends AnyShape>(
+	args: string[],
+	preset: Preset<OptionsShape>,
+	settings: CreateConfigSettings<InferredObject<OptionsShape>> = {},
+): Error | typeof settings {
+	const blocks = settings.blocks ?? {};
+	const remove = new Set(blocks.exclude);
+	const presetBlocks = new Map(
+		preset.blocks
+			.filter((block) => block.about?.name)
+			.map((block) => [
+				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+				block.about!.name!.toLowerCase().replaceAll(/\W+/gu, "-"),
+				block,
+			]),
+	);
+
+	for (const arg of args) {
+		const match = /--exclude-(\w+)/.exec(arg);
+		if (!match?.[1]) {
+			continue;
+		}
+
+		const removedBlock = presetBlocks.get(match[1]);
+		if (!removedBlock) {
+			return new Error(
+				`Block exclusion doesn't match any preset block: '${arg}'.`,
+			);
+		}
+
+		remove.add(removedBlock);
+	}
+
+	return remove.size
+		? {
+				...settings,
+				blocks: {
+					...blocks,
+					exclude: Array.from(remove),
+				},
+			}
+		: settings;
+}

--- a/packages/create/src/cli/readProductionSettings.test.ts
+++ b/packages/create/src/cli/readProductionSettings.test.ts
@@ -29,6 +29,42 @@ describe("readProductionSettings", () => {
 		expect(mockReaddir).toHaveBeenCalledWith(directory);
 	});
 
+	it("returns mode: initialize when the directory does not exist and mode is not provided", async () => {
+		mockReaddir.mockRejectedValueOnce(new Error("Oh no!"));
+
+		const actual = await readProductionSettings({
+			directory: "other",
+		});
+
+		expect(actual).toEqual({ mode: "initialize" });
+	});
+
+	it("returns mode: initialize when the directory does not exist and mode is initialize", async () => {
+		mockReaddir.mockRejectedValueOnce(new Error("Oh no!"));
+
+		const actual = await readProductionSettings({
+			directory: "other",
+			mode: "initialize",
+		});
+
+		expect(actual).toEqual({ mode: "initialize" });
+	});
+
+	it("returns an error when the directory does not exist and mode is migrate", async () => {
+		mockReaddir.mockRejectedValueOnce(new Error("Oh no!"));
+
+		const actual = await readProductionSettings({
+			directory: "other",
+			mode: "migrate",
+		});
+
+		expect(actual).toEqual(
+			new Error(
+				"Cannot run with --mode migrate on a directory that does not yet exist.",
+			),
+		);
+	});
+
 	it("returns the config file and mode: migrate when a config file is found without a mode", async () => {
 		const configFile = "create.config.ts";
 		mockReaddir.mockResolvedValueOnce([configFile]);

--- a/packages/create/src/cli/readProductionSettings.ts
+++ b/packages/create/src/cli/readProductionSettings.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs/promises";
 import path from "node:path";
 
 import { ProductionMode } from "../types/modes.js";
+import { tryCatchAsync } from "../utils/tryCatchAsync.js";
 import { ProductionSettings } from "./types.js";
 
 export interface ReadProductionSettingsOptions {
@@ -13,8 +14,16 @@ export async function readProductionSettings({
 	directory = ".",
 	mode,
 }: ReadProductionSettingsOptions = {}): Promise<Error | ProductionSettings> {
-	const items = await fs.readdir(directory);
+	const items = await tryCatchAsync(fs.readdir(directory));
 	let defaultMode: ProductionMode = mode ?? "initialize";
+
+	if (!items) {
+		return defaultMode === "migrate"
+			? new Error(
+					"Cannot run with --mode migrate on a directory that does not yet exist.",
+				)
+			: { mode: defaultMode };
+	}
 
 	for (const item of items) {
 		if (/create\.config\.\w+/.test(item)) {

--- a/packages/create/src/config/types.ts
+++ b/packages/create/src/config/types.ts
@@ -4,7 +4,7 @@ import { Preset } from "../types/presets.js";
 
 export interface BlockModifications<Options extends object = object> {
 	add?: Block<object | undefined, Options>[];
-	remove?: Block<object | undefined, Options>[];
+	exclude?: Block<object | undefined, Options>[];
 }
 
 export interface CreateConfig {

--- a/packages/create/src/mergers/getUpdatedBlockAddons.ts
+++ b/packages/create/src/mergers/getUpdatedBlockAddons.ts
@@ -11,6 +11,7 @@ export interface BlockProduction<
 }
 
 export function getUpdatedBlockAddons<Options extends object>(
+	allowedBlocks: Set<Block<object | undefined, Options>>,
 	blockProductions: Map<
 		Block<object | undefined, Options>,
 		BlockProduction<object, Options>
@@ -20,6 +21,10 @@ export function getUpdatedBlockAddons<Options extends object>(
 	const updated: [BlockWithAddons<object, Options>, object][] = [];
 
 	for (const newAddons of newBlockAddons) {
+		if (!allowedBlocks.has(newAddons.block)) {
+			continue;
+		}
+
 		const existingProduction = blockProductions.get(newAddons.block);
 		if (!existingProduction) {
 			updated.push([newAddons.block, newAddons.addons]);

--- a/packages/create/src/producers/applyBlockModifications.test.ts
+++ b/packages/create/src/producers/applyBlockModifications.test.ts
@@ -37,7 +37,7 @@ describe("runPreset", () => {
 	it("returns the initial blocks when modifications are empty", () => {
 		const initial = [blockA, blockB];
 
-		const actual = applyBlockModifications(initial, { add: [], remove: [] });
+		const actual = applyBlockModifications(initial, { add: [], exclude: [] });
 
 		expect(actual).toBe(initial);
 	});
@@ -47,7 +47,7 @@ describe("runPreset", () => {
 
 		const actual = applyBlockModifications(initial, {
 			add: [blockC],
-			remove: [blockB],
+			exclude: [blockB],
 		});
 
 		expect(actual).toEqual([blockA, blockC]);

--- a/packages/create/src/producers/applyBlockModifications.ts
+++ b/packages/create/src/producers/applyBlockModifications.ts
@@ -3,9 +3,9 @@ import { Block } from "../types/blocks.js";
 
 export function applyBlockModifications<Options extends object>(
 	initial: Block<object | undefined, Options>[],
-	{ add = [], remove = [] }: BlockModifications<Options> = {},
+	{ add = [], exclude = [] }: BlockModifications<Options> = {},
 ) {
-	if (!add.length && !remove.length) {
+	if (!add.length && !exclude.length) {
 		return initial;
 	}
 
@@ -15,8 +15,8 @@ export function applyBlockModifications<Options extends object>(
 		blocks.add(added);
 	}
 
-	for (const removed of remove) {
-		blocks.delete(removed);
+	for (const excluded of exclude) {
+		blocks.delete(excluded);
 	}
 
 	return Array.from(blocks);

--- a/packages/create/src/producers/executePresetBlocks.test.ts
+++ b/packages/create/src/producers/executePresetBlocks.test.ts
@@ -78,6 +78,47 @@ describe("runPreset", () => {
 		});
 	});
 
+	it("doesn't include addons to blocks that aren't defined", () => {
+		const blockKnown = base.createBlock({
+			about: {
+				name: "Known Block",
+			},
+			produce({ options }) {
+				return {
+					addons: [blockUnknown({ extra: "line" })],
+					files: { "README.md": options.value },
+				};
+			},
+		});
+
+		const blockUnknown = base.createBlock({
+			about: {
+				name: "Unknown Block",
+			},
+			addons: {
+				extra: z.string().optional(),
+			},
+			produce({ addons, options }) {
+				return {
+					files: { "UNKNOWN.md": [options.value, addons.extra].join("\n") },
+				};
+			},
+		});
+
+		const result = executePresetBlocks({
+			blocks: [blockKnown],
+			options: { value: "Hello, world!" },
+			presetContext,
+		});
+
+		expect(result).toEqual({
+			addons: [blockUnknown({ extra: "line" })],
+			files: {
+				"README.md": "Hello, world!",
+			},
+		});
+	});
+
 	describe("modes", () => {
 		const block = base.createBlock({
 			about: {

--- a/packages/create/src/producers/executePresetBlocks.ts
+++ b/packages/create/src/producers/executePresetBlocks.ts
@@ -35,6 +35,7 @@ export function executePresetBlocks<Options extends object>({
 	>(addons?.map((addon) => [addon.block, { addons: addon.addons as object }]));
 
 	// 1. Create a queue of Blocks to be run, starting with all defined in the Preset
+	const allowedBlocks = new Set(blocks);
 	const blocksToBeRun = new Set(blocks);
 
 	// 2. For each Block in the queue:
@@ -62,8 +63,9 @@ export function executePresetBlocks<Options extends object>({
 				creation: blockCreation,
 			});
 
-			// 2.4. If the Block specified new addons for any other Blocks:
+			// 2.4. If the Block specified new addons for any defined Blocks:
 			const updatedBlockAddons = getUpdatedBlockAddons(
+				allowedBlocks,
 				blockProductions,
 				blockCreation.addons,
 			);

--- a/packages/create/src/utils/tryCatchAsync.ts
+++ b/packages/create/src/utils/tryCatchAsync.ts
@@ -1,0 +1,7 @@
+export async function tryCatchAsync<T>(promise: Promise<T>) {
+	try {
+		return await promise;
+	} catch {
+		return undefined;
+	}
+}

--- a/packages/site/src/content/docs/cli.md
+++ b/packages/site/src/content/docs/cli.md
@@ -138,9 +138,9 @@ npx create typescript-app --mode initialize
 
 > Type: `string`
 
-Which [Preset](./concepts/presets) to use from the template.
+Which [Preset](./engine/concepts/presets) to use from the template.
 
-If not provided, and the template defines multiple Presets, `create` will prompt the user to select one.
+If not provided, and the template defines multiple presets, `create` will prompt the user to select one.
 
 For example, specifying the _common_ preset for [`create-typescript-app`](https://github.com/JoshuaKGoldberg/create-typescript-app):
 
@@ -158,14 +158,26 @@ Prints the `create` package version.
 npx create --version
 ```
 
-### Template Options
+## Template Options
 
 The template being generated from may add in additional flags.
 
-For example, if a template's Base defines a `title` option, `--title` will be type `string`:
+For example, if a template defines a `title` option, `--title` will be type `string`:
 
 ```shell
 npx create typescript-app --title "My New App"
 ```
 
 Any required options that are not provided will be prompted for by the `create` CLI.
+
+See the documentation for your specific template for additional flags.
+
+### Block Exclusions
+
+Individual [Blocks](./engine/concepts/blocks) from a template may be excluded with `--exclude-*` flags, where `*` is the `kebab-case` name of the Block.
+
+For example, if a Block is named `Vitest`, its exclusion flag would be `--exclude-vitest`:
+
+```ts
+npx create typescript-app --exclude-vitest
+```

--- a/packages/site/src/content/docs/configuration.md
+++ b/packages/site/src/content/docs/configuration.md
@@ -71,11 +71,11 @@ export default createConfig(presetEverything, {
 
 Running `npx create` in a repository with that configuration file would add in the created outputs from `blockAreTheTypesWrong`.
 
-#### `remove`
+#### `exclude`
 
-Any Blocks to remove from what the Preset provides.
+Any Blocks to exclude from what the Preset provides.
 
-For example, this configuration file removes the default _"This package was templated with..."_ notice that comes with `create-typescript-app`:
+For example, this configuration file omits the default _"This package was templated with..."_ notice that comes with `create-typescript-app`:
 
 ```ts title="create.config.js"
 import { createConfig } from "create";
@@ -83,7 +83,7 @@ import { blockTemplatedBy, presetEverything } from "create-typescript-app";
 
 export default createConfig(presetEverything, {
 	blocks: {
-		remove: [blockTemplatedBy],
+		exclude: [blockTemplatedBy],
 	},
 });
 ```

--- a/packages/site/src/content/docs/engine/apis/producers.md
+++ b/packages/site/src/content/docs/engine/apis/producers.md
@@ -264,7 +264,7 @@ See [Configuration > `addons`](../../configuration#addons) for how this is used.
 
 Any Blocks to `add` and/or `remove`.
 
-For example, this production adds a Jest Block and removes a Vitest Block:
+For example, this production swaps in a Jest Block instead of a Vitest Block:
 
 ```ts
 import { Preset, producePreset } from "create";
@@ -278,7 +278,7 @@ declare const preset: Preset<{ name: z.ZodString }>;
 await producePreset(preset, {
 	blocks: {
 		add: [blockJest],
-		remove: [blockVitest],
+		exclude: [blockVitest],
 	},
 	options: {
 		name: "My Production",

--- a/packages/site/src/content/docs/engine/apis/runners.md
+++ b/packages/site/src/content/docs/engine/apis/runners.md
@@ -25,6 +25,8 @@ For APIs that only create those objects in memory, see [Producers](./producers).
 
 Given a [Block](../concepts/blocks), executes a [Creation](../runtime/creations) output by running its [`produce()`](../concepts/blocks#production).
 
+See [Producers > `runBlock`](./producers#runblock) for the arguments `runBlock` allows.
+
 For example, given a Block that creates a `README.md`, this would write that file to system:
 
 ```ts
@@ -37,6 +39,8 @@ await runBlock(blockReadme);
 ## `runPreset`
 
 Given a [Preset](../concepts/presets), executes a [Creation](../runtime/creations) output by running each of its Blocks [`produce()`](../concepts/blocks#production).
+
+See [Producers > `produceBlock`](./producers#produceblock) for the arguments `runPreset` allows.
 
 For example, given a Preset containing the previous Block that creates a `README.md`, this would write that file to system:
 

--- a/packages/site/src/content/docs/engine/runtime/execution.md
+++ b/packages/site/src/content/docs/engine/runtime/execution.md
@@ -10,7 +10,7 @@ The steps [`runPreset`](../apis/producers#producepreset) takes internally are:
    1. Get the Creation from the Block, passing any current known Addons
    2. Store that Block's Creation
    3. If a [runtime mode](#modes) is specified, additionally generate the approprate Block Creations
-   4. If the Block specified new addons for any other Blocks:
+   4. If the Block specified new addons for any defined Blocks:
       1. Add those Blocks to the queue of Blocks to re-run
 3. Merge all Block Creations together
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #102
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Also fixes an engine-level issue: if a defined Block provides Addons for non-defined Block, the non-defined Block shouldn't be run.

Switches the config file `settings.blocks` setting from `remove` to `exclude` to match the naming.

💖 