### PR TITLE
feat: --offline

### DIFF
--- a/packages/create-testers/src/createMockSystems.ts
+++ b/packages/create-testers/src/createMockSystems.ts
@@ -12,7 +12,7 @@ export interface MockSystems {
 export function createMockSystems(
 	settings: MockSystemOptions = {},
 ): MockSystems {
-	const fetch = settings.fetch ?? createFailingFunction("fetcher", "an input");
+	const fetch = settings.fetch ?? createFailingFunction("fetch", "an input");
 
 	const fetchers = {
 		fetch,

--- a/packages/create-testers/src/testBlock.ts
+++ b/packages/create-testers/src/testBlock.ts
@@ -1,9 +1,9 @@
 import {
-	BlockProductionSettingsWithAddons,
 	BlockWithAddons,
 	BlockWithoutAddons,
 	Creation,
 	produceBlock,
+	ProduceBlockSettingsWithAddons,
 	ProductionMode,
 } from "create";
 
@@ -39,6 +39,6 @@ export function testBlock<Addons extends object, Options extends object>(
 			addons: {},
 			options: createFailingObject("options", "the Block") as Options,
 			...settings,
-		} as BlockProductionSettingsWithAddons<Addons, Options>,
+		} as ProduceBlockSettingsWithAddons<Addons, Options>,
 	);
 }

--- a/packages/create/src/cli/createInitialCommit.test.ts
+++ b/packages/create/src/cli/createInitialCommit.test.ts
@@ -26,7 +26,7 @@ describe("createInitialCommit", () => {
 	test("runs with --amend when amend is true", async () => {
 		const runner = vi.fn();
 
-		await createInitialCommit(runner, true);
+		await createInitialCommit(runner, { amend: true });
 
 		expect(runner.mock.calls).toMatchInlineSnapshot(`
 			[
@@ -38,6 +38,23 @@ describe("createInitialCommit", () => {
 			  ],
 			  [
 			    "git push -u origin main --force",
+			  ],
+			]
+		`);
+	});
+
+	test("doesn't push when offline is true", async () => {
+		const runner = vi.fn();
+
+		await createInitialCommit(runner, { offline: true });
+
+		expect(runner.mock.calls).toMatchInlineSnapshot(`
+			[
+			  [
+			    "git add -A",
+			  ],
+			  [
+			    "git commit --message feat:\\ initialized\\ repo\\ ✨ --no-gpg-sign",
 			  ],
 			]
 		`);

--- a/packages/create/src/cli/createInitialCommit.ts
+++ b/packages/create/src/cli/createInitialCommit.ts
@@ -1,13 +1,18 @@
 import { SystemRunner } from "../types/system.js";
 
+export interface CreateInitialCommitSettings {
+	amend?: boolean;
+	offline?: boolean;
+}
+
 export async function createInitialCommit(
 	runner: SystemRunner,
-	amend?: boolean,
+	{ amend, offline }: CreateInitialCommitSettings = {},
 ) {
 	for (const command of [
 		`git add -A`,
 		`git commit --message feat:\\ initialized\\ repo\\ ✨ ${amend ? "--amend " : ""}--no-gpg-sign`,
-		`git push -u origin main --force`,
+		...(offline ? [] : [`git push -u origin main --force`]),
 	]) {
 		await runner(command);
 	}

--- a/packages/create/src/cli/prompts/promptForBaseOptions.ts
+++ b/packages/create/src/cli/prompts/promptForBaseOptions.ts
@@ -7,22 +7,22 @@ import { SystemContext } from "../../types/system.js";
 import { promptForSchema } from "./promptForSchema.js";
 
 export interface PromptForBaseOptionsSettings {
-	base: Base;
 	existingOptions: Partial<InferredObject<AnyShape>>;
+	offline?: boolean;
 	system: SystemContext;
 }
 
-export async function promptForBaseOptions({
-	base,
-	existingOptions,
-	system,
-}: PromptForBaseOptionsSettings) {
+export async function promptForBaseOptions(
+	base: Base,
+	{ existingOptions, offline, system }: PromptForBaseOptionsSettings,
+) {
 	const { directory } = system;
 	const options: InferredObject<AnyShape> = {
 		directory,
 		...existingOptions,
 		...(await produceBase(base, {
 			...system,
+			offline,
 			options: { ...existingOptions, directory },
 		})),
 	};

--- a/packages/create/src/cli/runCli.ts
+++ b/packages/create/src/cli/runCli.ts
@@ -15,6 +15,7 @@ const valuesSchema = z.object({
 	directory: z.string().optional(),
 	from: z.string().optional(),
 	mode: z.union([z.literal("initialize"), z.literal("migrate")]).optional(),
+	offline: z.boolean().optional(),
 	owner: z.string().optional(),
 	preset: z.string().optional(),
 	repository: z.string().optional(),
@@ -35,6 +36,9 @@ export async function runCli(args: string[]) {
 			},
 			mode: {
 				type: "string",
+			},
+			offline: {
+				type: "boolean",
 			},
 			owner: {
 				type: "string",

--- a/packages/create/src/producers/applyBlockModifications.test.ts
+++ b/packages/create/src/producers/applyBlockModifications.test.ts
@@ -25,7 +25,7 @@ const blockC = base.createBlock({
 	produce: vi.fn(),
 });
 
-describe("runPreset", () => {
+describe("applyBlockModifications", () => {
 	it("returns the initial blocks when no modifications are provided", () => {
 		const initial = [blockA, blockB];
 

--- a/packages/create/src/producers/produceBase.ts
+++ b/packages/create/src/producers/produceBase.ts
@@ -1,25 +1,20 @@
 import { AnyShape, InferredObject } from "../options.js";
 import { createSystemContextWithAuth } from "../system/createSystemContextWithAuth.js";
-import { Base, LazyOptionalOptions } from "../types/bases.js";
+import { Base } from "../types/bases.js";
 import { NativeSystem } from "../types/system.js";
-import {
-	AwaitedLazyProperties,
-	awaitLazyProperties,
-} from "../utils/awaitLazyProperties.js";
+import { awaitLazyProperties } from "../utils/awaitLazyProperties.js";
 
-export type BaseProduction<OptionsShape extends AnyShape> =
-	AwaitedLazyProperties<LazyOptionalOptions<InferredObject<OptionsShape>>>;
-
-export interface BaseProductionSettings<OptionsShape extends AnyShape>
+export interface ProduceBaseSettings<OptionsShape extends AnyShape>
 	extends Partial<NativeSystem> {
 	directory?: string;
+	offline?: boolean;
 	options?: Partial<InferredObject<OptionsShape>>;
 }
 
 export async function produceBase<OptionsShape extends AnyShape>(
 	base: Base<OptionsShape>,
-	settings: BaseProductionSettings<OptionsShape> = {},
-): Promise<Partial<BaseProduction<OptionsShape>>> {
+	settings: ProduceBaseSettings<OptionsShape> = {},
+): Promise<Partial<InferredObject<OptionsShape>>> {
 	if (!base.produce) {
 		return settings.options ?? {};
 	}

--- a/packages/create/src/producers/produceBlock.ts
+++ b/packages/create/src/producers/produceBlock.ts
@@ -4,40 +4,40 @@ import {
 	BlockWithAddons,
 	BlockWithoutAddons,
 } from "../types/blocks.js";
-import { Creation, IndirectCreation } from "../types/creations.js";
+import { Creation } from "../types/creations.js";
 import { ProductionMode } from "../types/modes.js";
 
-export type BlockProductionSettings<
+export type ProduceBlockSettings<
 	Addons extends object | undefined,
 	Options extends object,
 > = Addons extends object
-	? BlockProductionSettingsWithAddons<Addons, Options>
-	: BlockProductionSettingsWithoutAddons<Options>;
+	? ProduceBlockSettingsWithAddons<Addons, Options>
+	: ProduceBlockSettingsWithoutAddons<Options>;
 
-export interface BlockProductionSettingsWithAddons<
+export interface ProduceBlockSettingsWithAddons<
 	Addons extends object,
 	Options extends object,
-> extends BlockProductionSettingsWithoutAddons<Options> {
+> extends ProduceBlockSettingsWithoutAddons<Options> {
 	addons?: Addons;
 }
 
-export interface BlockProductionSettingsWithoutAddons<Options extends object> {
-	created?: Partial<IndirectCreation<Options>>;
+export interface ProduceBlockSettingsWithoutAddons<Options extends object> {
 	mode?: ProductionMode;
+	offline?: boolean;
 	options: Options;
 }
 
 export function produceBlock<Addons extends object, Options extends object>(
 	block: BlockWithAddons<Addons, Options>,
-	settings: BlockProductionSettingsWithAddons<Addons, Options>,
+	settings: ProduceBlockSettingsWithAddons<Addons, Options>,
 ): Partial<Creation<Options>>;
 export function produceBlock<Options extends object>(
 	block: BlockWithoutAddons<Options>,
-	settings: BlockProductionSettingsWithoutAddons<Options>,
+	settings: ProduceBlockSettingsWithoutAddons<Options>,
 ): Partial<Creation<Options>>;
 export function produceBlock<Addons extends object, Options extends object>(
 	block: BlockWithAddons<Addons, Options> | BlockWithoutAddons<Options>,
-	settings: BlockProductionSettings<Addons, Options>,
+	settings: ProduceBlockSettings<Addons, Options>,
 ): Partial<Creation<Options>> {
 	let creation = block.produce(
 		settings as BlockContextWithAddons<Addons, Options>,

--- a/packages/create/src/producers/produceBlocks.test.ts
+++ b/packages/create/src/producers/produceBlocks.test.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 
 import { createBase } from "../creators/createBase.js";
 import { createSystemFetchers } from "../system/createSystemFetchers.js";
-import { executePresetBlocks } from "./executePresetBlocks.js";
+import { produceBlocks } from "./produceBlocks.js";
 
 const presetContext = {
 	directory: ".",
@@ -36,10 +36,9 @@ describe("runPreset", () => {
 			},
 		});
 
-		const result = executePresetBlocks({
-			blocks: [block],
+		const result = produceBlocks([block], {
 			options: { value: "Hello, world!" },
-			presetContext,
+			system: presetContext,
 		});
 
 		expect(result).toEqual({
@@ -64,11 +63,10 @@ describe("runPreset", () => {
 			},
 		});
 
-		const result = executePresetBlocks({
+		const result = produceBlocks([block], {
 			addons: [block({ extra: "line" })],
-			blocks: [block],
 			options: { value: "Hello, world!" },
-			presetContext,
+			system: presetContext,
 		});
 
 		expect(result).toEqual({
@@ -105,10 +103,9 @@ describe("runPreset", () => {
 			},
 		});
 
-		const result = executePresetBlocks({
-			blocks: [blockKnown],
+		const result = produceBlocks([blockKnown], {
 			options: { value: "Hello, world!" },
-			presetContext,
+			system: presetContext,
 		});
 
 		expect(result).toEqual({
@@ -144,10 +141,9 @@ describe("runPreset", () => {
 		});
 
 		it("does not augment creations with a Block's initialize() or migrate() when mode is undefined", () => {
-			const result = executePresetBlocks({
-				blocks: [block],
+			const result = produceBlocks([block], {
 				options: { value: "Hello, world!" },
-				presetContext,
+				system: presetContext,
 			});
 
 			expect(result).toEqual({
@@ -158,11 +154,10 @@ describe("runPreset", () => {
 		});
 
 		it("augments creations with a Block's initialize() when mode is 'initialize'", () => {
-			const result = executePresetBlocks({
-				blocks: [block],
+			const result = produceBlocks([block], {
 				mode: "initialize",
 				options: { value: "Hello, world!" },
-				presetContext,
+				system: presetContext,
 			});
 
 			expect(result).toEqual({
@@ -174,11 +169,10 @@ describe("runPreset", () => {
 		});
 
 		it("augments creations with a Block's migrate() when mode is 'migrate'", () => {
-			const result = executePresetBlocks({
-				blocks: [block],
+			const result = produceBlocks([block], {
 				mode: "migrate",
 				options: { value: "Hello, world!" },
-				presetContext,
+				system: presetContext,
 			});
 
 			expect(result).toEqual({

--- a/packages/create/src/producers/produceBlocks.test.ts
+++ b/packages/create/src/producers/produceBlocks.test.ts
@@ -96,11 +96,7 @@ describe("runPreset", () => {
 			addons: {
 				extra: z.string().optional(),
 			},
-			produce({ addons, options }) {
-				return {
-					files: { "UNKNOWN.md": [options.value, addons.extra].join("\n") },
-				};
-			},
+			produce: vi.fn(),
 		});
 
 		const result = produceBlocks([blockKnown], {

--- a/packages/create/src/producers/produceInput.ts
+++ b/packages/create/src/producers/produceInput.ts
@@ -2,16 +2,17 @@ import { createSystemContext } from "../system/createSystemContext.js";
 import { Input } from "../types/inputs.js";
 import { NativeSystem } from "../types/system.js";
 
-export interface InputProductionSettings<Args extends object = object>
+export interface ProduceInputSettings<Args extends object = object>
 	extends Partial<NativeSystem> {
 	args: Args;
 	auth?: string;
 	directory?: string;
+	offline?: boolean;
 }
 
 export function produceInput<Result, Args extends object>(
 	input: Input<Result, Args>,
-	settings: InputProductionSettings<Args>,
+	settings: ProduceInputSettings<Args>,
 ) {
 	const system = createSystemContext({
 		directory: settings.directory ?? ".",

--- a/packages/create/src/producers/producePreset.test.ts
+++ b/packages/create/src/producers/producePreset.test.ts
@@ -27,28 +27,28 @@ const system = {
 };
 
 describe("producePreset", () => {
-	const baseWithOption = createBase({
-		options: {
-			value: z.string(),
-		},
-	});
-
-	const blockUsingOption = baseWithOption.createBlock({
-		produce({ options }) {
-			return {
-				files: {
-					"value.txt": options.value,
-				},
-			};
-		},
-	});
-
-	const presetUsingOption = baseWithOption.createPreset({
-		about: { name: "Test" },
-		blocks: [blockUsingOption],
-	});
-
 	it("passes options to the preset when provided via options", async () => {
+		const baseWithOption = createBase({
+			options: {
+				value: z.string(),
+			},
+		});
+
+		const blockUsingOption = baseWithOption.createBlock({
+			produce({ options }) {
+				return {
+					files: {
+						"value.txt": options.value,
+					},
+				};
+			},
+		});
+
+		const presetUsingOption = baseWithOption.createPreset({
+			about: { name: "Test" },
+			blocks: [blockUsingOption],
+		});
+
 		const actual = await producePreset(presetUsingOption, {
 			...system,
 			options: {
@@ -60,6 +60,40 @@ describe("producePreset", () => {
 			...emptyCreation,
 			files: {
 				"value.txt": "abc",
+			},
+		});
+	});
+
+	it("passes offline to the preset when provided", async () => {
+		const baseWithoutOption = createBase({
+			options: {},
+		});
+
+		const blockWithoutOption = baseWithoutOption.createBlock({
+			produce({ offline }) {
+				return {
+					files: {
+						"offline.txt": String(offline),
+					},
+				};
+			},
+		});
+
+		const presetWithoutOption = baseWithoutOption.createPreset({
+			about: { name: "Test" },
+			blocks: [blockWithoutOption],
+		});
+
+		const actual = await producePreset(presetWithoutOption, {
+			...system,
+			offline: true,
+			options: {},
+		});
+
+		expect(actual).toEqual({
+			...emptyCreation,
+			files: {
+				"offline.txt": "true",
 			},
 		});
 	});

--- a/packages/create/src/runners/runBlock.test.ts
+++ b/packages/create/src/runners/runBlock.test.ts
@@ -14,7 +14,7 @@ const base = createBase({
 function createSystem() {
 	return {
 		fetchers: {
-			fetch: noop("fetcher"),
+			fetch: noop("fetch"),
 			octokit: {} as Octokit,
 		},
 		fs: {

--- a/packages/create/src/runners/runCreation.ts
+++ b/packages/create/src/runners/runCreation.ts
@@ -4,9 +4,14 @@ import { applyFilesToSystem } from "./applyFilesToSystem.js";
 import { applyRequestsToSystem } from "./applyRequestsToSystem.js";
 import { applyScriptsToSystem } from "./applyScriptsToSystem.js";
 
-export async function applyCreation(
+export interface ApplyCreationSettings {
+	offline?: boolean;
+	system: SystemContext;
+}
+
+export async function runCreation(
 	creation: Partial<DirectCreation>,
-	system: SystemContext,
+	{ offline, system }: ApplyCreationSettings,
 ) {
 	if (creation.files) {
 		await applyFilesToSystem(creation.files, system.fs, system.directory);
@@ -14,6 +19,8 @@ export async function applyCreation(
 
 	await Promise.all([
 		creation.scripts && applyScriptsToSystem(creation.scripts, system),
-		creation.requests && applyRequestsToSystem(creation.requests, system),
+		!offline &&
+			creation.requests &&
+			applyRequestsToSystem(creation.requests, system),
 	]);
 }

--- a/packages/create/src/runners/runPreset.test.ts
+++ b/packages/create/src/runners/runPreset.test.ts
@@ -14,7 +14,7 @@ const base = createBase({
 function createSystem() {
 	return {
 		fetchers: {
-			fetch: noop("fetcher"),
+			fetch: noop("fetch"),
 			octokit: {} as Octokit,
 		},
 		fs: {

--- a/packages/create/src/runners/runPreset.ts
+++ b/packages/create/src/runners/runPreset.ts
@@ -8,12 +8,13 @@ import { CreatedBlockAddons, Creation } from "../types/creations.js";
 import { ProductionMode } from "../types/modes.js";
 import { Preset } from "../types/presets.js";
 import { NativeSystem } from "../types/system.js";
-import { applyCreation } from "./applyCreation.js";
+import { runCreation } from "./runCreation.js";
 
-export interface PresetRunSettings<OptionsShape extends AnyShape>
+export interface RunPresetSettings<OptionsShape extends AnyShape>
 	extends RunSettingsBase {
 	addons?: CreatedBlockAddons<object, InferredObject<OptionsShape>>[];
 	blocks?: BlockModifications<InferredObject<OptionsShape>>;
+	offline?: boolean;
 	options: InferredObject<OptionsShape>;
 }
 
@@ -21,13 +22,14 @@ export interface RunSettingsBase extends Partial<NativeSystem> {
 	auth?: string;
 	directory?: string;
 	mode?: ProductionMode;
+	offline?: boolean;
 }
 
 export async function runPreset<OptionsShape extends AnyShape>(
 	preset: Preset<OptionsShape>,
-	settings: PresetRunSettings<OptionsShape>,
+	settings: RunPresetSettings<OptionsShape>,
 ): Promise<Creation<InferredObject<OptionsShape>>> {
-	const { directory = "." } = settings;
+	const { directory = ".", offline } = settings;
 	await fs.mkdir(directory, { recursive: true });
 
 	const system = await createSystemContextWithAuth({
@@ -37,7 +39,7 @@ export async function runPreset<OptionsShape extends AnyShape>(
 
 	const creation = await producePreset(preset, { ...system, ...settings });
 
-	await applyCreation(creation, system);
+	await runCreation(creation, { offline, system });
 
 	return creation;
 }

--- a/packages/create/src/system/createOfflineFetchers.test.ts
+++ b/packages/create/src/system/createOfflineFetchers.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+
+import { createOfflineFetchers } from "./createOfflineFetchers.js";
+
+describe("createOfflineFetchers", () => {
+	it("rejects when called", async () => {
+		const fetchers = createOfflineFetchers();
+
+		await expect(
+			async () => await fetchers.fetch(""),
+		).rejects.toMatchInlineSnapshot(
+			`[Error: Offline specified. This request should be caught by its Input.]`,
+		);
+	});
+});

--- a/packages/create/src/system/createOfflineFetchers.ts
+++ b/packages/create/src/system/createOfflineFetchers.ts
@@ -1,0 +1,13 @@
+import { SystemFetchers } from "../types/system.js";
+import { createSystemFetchers } from "./createSystemFetchers.js";
+
+export function createOfflineFetchers(): SystemFetchers {
+	return createSystemFetchers({
+		fetch: () =>
+			Promise.reject(
+				new Error(
+					"Offline specified. This request should be caught by its Input.",
+				),
+			),
+	});
+}

--- a/packages/create/src/system/createSystemContext.test.ts
+++ b/packages/create/src/system/createSystemContext.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createSystemContext } from "./createSystemContext.js";
+
+const mockOfflineFetchers = {
+	variant: "offline",
+};
+
+vi.mock("./createOfflineFetchers", () => ({
+	createOfflineFetchers: () => mockOfflineFetchers,
+}));
+
+const mockSystemFetchers = {
+	variant: "system",
+};
+
+vi.mock("./createSystemFetchers", () => ({
+	createSystemFetchers: () => mockSystemFetchers,
+}));
+
+describe("createSystemContext", () => {
+	describe("fetchers", () => {
+		it("creates standard fetchers when fetchers and offline are not provided", () => {
+			const { fetchers } = createSystemContext({ directory: "." });
+
+			expect(fetchers).toBe(mockSystemFetchers);
+		});
+
+		it("creates offline fetchers when fetchers is not provided and offline is true", () => {
+			const { fetchers } = createSystemContext({
+				directory: ".",
+				offline: true,
+			});
+
+			expect(fetchers).toBe(mockOfflineFetchers);
+		});
+	});
+});

--- a/packages/create/src/system/createSystemContext.ts
+++ b/packages/create/src/system/createSystemContext.ts
@@ -1,5 +1,6 @@
 import { TakeInput } from "../types/inputs.js";
 import { NativeSystem, SystemContext, SystemDisplay } from "../types/system.js";
+import { createOfflineFetchers } from "./createOfflineFetchers.js";
 import { createSystemDisplay } from "./createSystemDisplay.js";
 import { createSystemFetchers } from "./createSystemFetchers.js";
 import { createSystemRunner } from "./createSystemRunner.js";
@@ -9,13 +10,18 @@ export interface SystemContextSettings extends Partial<NativeSystem> {
 	auth?: string;
 	directory: string;
 	display?: SystemDisplay;
+	offline?: boolean;
 }
 
 export function createSystemContext(
 	settings: SystemContextSettings,
 ): SystemContext {
 	const system: NativeSystem = {
-		fetchers: settings.fetchers ?? createSystemFetchers(settings),
+		fetchers:
+			settings.fetchers ??
+			(settings.offline
+				? createOfflineFetchers()
+				: createSystemFetchers(settings)),
 		fs: settings.fs ?? createWritingFileSystem(),
 		runner: settings.runner ?? createSystemRunner(settings.directory),
 	};

--- a/packages/create/src/system/createSystemContextWithAuth.ts
+++ b/packages/create/src/system/createSystemContextWithAuth.ts
@@ -9,7 +9,7 @@ export async function createSystemContextWithAuth(
 	settings: SystemContextSettings,
 ) {
 	const authToken =
-		settings.fetchers?.octokit || settings.auth
+		settings.fetchers?.octokit || settings.auth || settings.offline
 			? undefined
 			: await getGitHubAuthToken();
 	const auth = authToken?.succeeded ? authToken.token : settings.auth;

--- a/packages/create/src/types/blocks.ts
+++ b/packages/create/src/types/blocks.ts
@@ -41,6 +41,7 @@ export interface BlockContextWithOptionalAddons<
 }
 
 export interface BlockContextWithoutAddons<Options extends object> {
+	offline?: boolean;
 	options: Options;
 }
 

--- a/packages/site/src/content/docs/about.mdx
+++ b/packages/site/src/content/docs/about.mdx
@@ -15,7 +15,7 @@ See **[CLI](./cli)** to generate your first repository from a template with the 
 
 <PackageManagers type="dlx" pkg="create" args="typescript-app" />
 
-`create` also provides rich scaffolding for building flexible repostiroy templates that describe the files and settings for projects, as well as configurable, type-safe options for customizations.
+`create` also provides rich scaffolding for building flexible repository templates that describe the files and settings for projects, as well as configurable, type-safe options for customizations.
 
 ## Why?
 

--- a/packages/site/src/content/docs/cli.mdx
+++ b/packages/site/src/content/docs/cli.mdx
@@ -12,7 +12,7 @@ It will interactively prompt you for any options it needs to run that can't be i
 
 ## Modes
 
-The `create` CLI will automatically detect which [`-m`/`--mode`](#-m----mode) it is being run in:
+The `create` CLI will automatically detect which [`--mode`](#-m----mode) it is being run in:
 
 - [Initialization](#initialization-mode): Creating a new repository from a template
 - [Migration](#migration-mode): Updating an existing repositories to a new version of a template
@@ -63,7 +63,7 @@ For example, to update an existing repository to the latest [`create-typescript-
 
 ## Flags
 
-The first argument passed to `create` can be a shorthand [`-f` / `--from`](#-f----from) for an npm package default-exporting a [Template](./concepts/templates).
+The first argument passed to `create` can be a shorthand `--from`](#-f----from) for an npm package default-exporting a [Template](./concepts/templates).
 A shorthand name excludes the `create-` prefix to an npm package name that starts with `create-`.
 
 :::tip
@@ -71,7 +71,7 @@ The `create` CLI is a general runner to pull in information from templates.
 See the documentation for your specific template for additional flags.
 :::
 
-### `-d` / `--directory`
+### `--directory`
 
 > Type: `string`
 
@@ -90,7 +90,7 @@ For example, creating a new repository in a subdirectory:
 	args="typescript-app --directory my-fancy-project"
 />
 
-### `-f` / `--from`
+### `--from`
 
 > Type: `string`
 
@@ -110,7 +110,7 @@ For example, using an org-scoped package:
 	args="--from @joshuakgoldberg/my-fancy-template"
 />
 
-### `-h` / `--help`
+### `--help`
 
 > Type: `boolean`
 
@@ -118,7 +118,7 @@ Prints help text.
 
 <PackageManagers type="dlx" pkg="create" args="--help" />
 
-### `-m` / `--mode`
+### `--mode`
 
 > Type: `string`
 
@@ -134,7 +134,26 @@ For example, specifying creating a new repository with [`create-typescript-app`]
 	args="typescript-app --mode initialize"
 />
 
-### `-p` / `--preset`
+### `--offline`
+
+> Type: `boolean`
+
+Whether to run in an "offline" mode that skips network requests.
+
+If provided, templates will be told not to make any network requests.
+That often means they will install from offline caches, skip creating a repository on GitHub, and skip sending GitHub API requests.
+The repository will roughly be a local-only creation.
+
+For example, specifying creating a new repository offline with [`create-typescript-app`](https://github.com/JoshuaKGoldberg/create-typescript-app):
+
+<PackageManagers type="dlx" pkg="create" args="typescript-app --offline" />
+
+:::caution
+`--offline` doesn't prevent templates from running scripts that may make network requests.
+If you are finding your template still sends requests offline, file a bug on the template.
+:::
+
+### `--preset`
 
 > Type: `string`
 
@@ -150,7 +169,7 @@ For example, specifying the _common_ preset for [`create-typescript-app`](https:
 	args="typescript-app --preset common"
 />
 
-### `-v` / `--version`
+### `--version`
 
 > Type: `boolean`
 

--- a/packages/site/src/content/docs/engine/apis/creators.mdx
+++ b/packages/site/src/content/docs/engine/apis/creators.mdx
@@ -488,8 +488,8 @@ For example, this Input fetches text from a URL:
 import { createInput } from "create";
 
 export const inputNow = createInput({
-	async produce({ fetcher }) {
-		return await (await fetcher("https://example.com")).text();
+	async produce({ fetchers }) {
+		return await (await fetchers.fetch("https://example.com")).text();
 	},
 });
 ```

--- a/packages/site/src/content/docs/engine/apis/producers.mdx
+++ b/packages/site/src/content/docs/engine/apis/producers.mdx
@@ -62,6 +62,30 @@ await produceBase(base, {
 If the Base does not define a `produce()`, then `settings.options` is returned.
 :::
 
+### `offline` {#producebase-offline}
+
+Whether to hint to the Base not to make network requests.
+
+This is equivalent to the [`--offline` CLI flag](../../cli#offline).
+If provided, [Input fetchers](../contexts#input-fetchers) will reject with an Error instead of resolving.
+
+For example, this Base is told to run offline:
+
+```ts
+import { Base } from "create";
+
+declare const base: Base<{}>;
+
+await produceBase(base, {
+	offline: true,
+});
+```
+
+:::caution
+`offline` doesn't prevent Bases from making network requests outside of the Input fetchers.
+If you are finding your template still sends requests offline, file a bug on the template.
+:::
+
 ### `options` {#producebase-options}
 
 Any number of options defined by the base.
@@ -135,6 +159,28 @@ await produceBlock(block, {
 ### `created` {#produceblock-created}
 
 Any [Creations](../runtime/contexts#created) to simulate having been made from previously-produced Blocks.
+
+### `offline` {#produceblock-offline}
+
+Whether to hint to the Block not to make network requests.
+
+This is equivalent to the [`--offline` CLI flag](../../cli#offline).
+If provided, [Input fetchers](../contexts#input-fetchers) will reject with an Error instead of resolving.
+
+For example, this Base is told to run offline:
+
+```ts
+import { produceBlock } from "create";
+
+import { base } from "./base";
+
+declare const block: Block<{}, {}>;
+
+await produceBlock(block, {
+	offline: {},
+	options: {},
+});
+```
 
 ### `options` {#produceblock-options}
 
@@ -288,6 +334,32 @@ await producePreset(preset, {
 
 See [Configuration > `blocks`](../../configuration#blocks) for how this is used.
 
+### `offline` {#producepreset-offline}
+
+Whether to hint to the Preset not to make network requests.
+
+This is equivalent to the [`--offline` CLI flag](../../cli#offline).
+If provided, [Input fetchers](../contexts#input-fetchers) will reject with an Error instead of resolving.
+
+For example, this Preset is told to run offline:
+
+```ts
+import { Base } from "create";
+import { z } from "zod";
+
+declare const preset: Preset<{}>;
+
+await producePreset(preset, {
+	offline: true,
+	options: {},
+});
+```
+
+:::caution
+`offline` doesn't prevent Presets from making network requests outside of the Input fetchers.
+If you are finding your template still sends requests offline, file a bug on the template.
+:::
+
 ### `options` {#preset-options}
 
 Any options defined by the Preset's [Base](../concepts/bases).
@@ -320,14 +392,20 @@ For example, this Block production adds an authorization header to all network r
 
 ```ts
 import { produceBlock } from "create";
+import { Octokit } from "octokit";
 
 import { blockUsingNetwork } from "./blockUsingNetwork";
 
+const fetch = async (...args) => {
+	const request = new Request(...args);
+	request.headers.set("Authorization", "Bearer ...");
+	return await fetch(request);
+};
+
 await produceBlock(blockUsingNetwork, {
-	fetcher: async (...args) => {
-		const request = new Request(...args);
-		request.headers.set("Authorization", "Bearer ...");
-		return await fetch(request);
+	fetchers: {
+		fetch,
+		octokit: new Octokit({ request: fetch }),
 	},
 });
 ```

--- a/packages/site/src/content/docs/engine/apis/testers.mdx
+++ b/packages/site/src/content/docs/engine/apis/testers.mdx
@@ -264,7 +264,7 @@ As with [`produceInput`](./producers#produceinput), `testInput` returns the data
 However, some properties will cause `testInput` to throw an error if they're not provided and the Input attempts to use them:
 
 - [`args`](#testinput-args): throws an error if accessed at all
-- [`fetcher`](#testinput-fetcher): by default, throws an error if called as a function
+- [`fetchers`](#testinput-fetchers): by default, each throw an error if called as a function
 - [`fs`](#testinput-fs): by default, each method throws an error if called as a function
 - [`runner`](#testinput-runner): by default, throws an error if called as a function
 
@@ -296,7 +296,7 @@ describe("inputFromFile", () => {
 });
 ```
 
-### `fetcher` {#testinput-fetcher}
+### `fetchers` {#testinput-fetchers}
 
 A mock function to act as the global [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API).
 
@@ -305,6 +305,7 @@ For example, this test asserts that an `inputCatFact` Input returns the `fact` p
 ```ts
 import { testInput } from "create-testers";
 import { describe, expect, it, vi } from "vitest";
+import { Octokit } from "octokit";
 
 import { inputCatFact } from "./inputCatFact";
 
@@ -313,14 +314,18 @@ describe("inputCatFact", () => {
 		const fact =
 			"Owning a cat is actually proven to be beneficial for your health.";
 
-		const fetcher = vi.fn().mockResolvedValueOnce({
+		const fetch = vi.fn().mockResolvedValueOnce({
 			json: () => Promise.resolve({ fact }),
 		});
+		const fetchers = {
+			fetch,
+			octokit: new Octokit({ request: fetch }),
+		};
 
-		const actual = await testInput(inputCatFact, { fetcher });
+		const actual = await testInput(inputCatFact, { fetchers });
 
 		expect(actual).toEqual(fact);
-		expect(fetcher).toHaveBeenCalledWith("https://catfact.ninja/fact");
+		expect(fetch).toHaveBeenCalledWith("https://catfact.ninja/fact");
 	});
 });
 ```
@@ -449,11 +454,11 @@ Both [Direct Creations](../runtime/creations#direct-creations) and [Indirect Cre
 `settings` and all its properties are optional.
 However, some properties will cause `testPreset` to throw an error if they're not provided and the Block attempts to use them:
 
-- [`fetcher`](#testpreset-fetcher): by default, throws an error if called as a function
+- [`fetchers`](#testpreset-fetchers): by default, throws an error if called as a function
 - [`fs`](#testpreset-fs): by default, each method throws an error if called as a function
 - [`runner`](#testpreset-runner): by default, throws an error if called as a function
 
-### `fetcher` {#testpreset-fetcher}
+### `fetchers` {#testpreset-fetchers}
 
 A mock function to act as the global [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API).
 
@@ -461,6 +466,7 @@ For example, this test asserts that a Preset internally fetches cat facts from a
 
 ```ts
 import { testPreset } from "create-testers";
+import { Octokit } from "octokit";
 import { describe, expect, it, vi } from "vitest";
 
 import { presetWithCatFact } from "./presetWithCatFact";
@@ -470,18 +476,21 @@ describe("presetWithCatFact", () => {
 		const fact =
 			"Owning a cat is actually proven to be beneficial for your health.";
 
-		const fetcher = vi.fn().mockResolvedValueOnce({
+		const fetch = vi.fn().mockResolvedValueOnce({
 			json: () => Promise.resolve({ fact }),
 		});
 
-		const actual = await testPreset(presetWithCatFact, { fetcher });
+		const actual = await testPreset(presetWithCatFact, {
+			fetch,
+			octokit: new Octokit({ request: fetch }),
+		});
 
 		expect(actual).toEqual({
 			files: {
 				"fact.txt": fact,
 			},
 		});
-		expect(fetcher).toHaveBeenCalledWith("https://catfact.ninja/fact");
+		expect(fetch).toHaveBeenCalledWith("https://catfact.ninja/fact");
 	});
 });
 ```

--- a/packages/site/src/content/docs/engine/runtime/contexts.mdx
+++ b/packages/site/src/content/docs/engine/runtime/contexts.mdx
@@ -116,9 +116,12 @@ export const inputFromFile = createInput({
 
 Unlike that minimal example, Inputs generally use one or more of the following properties to read from the user's file system and/or network.
 
-### `fetcher` {#input-fetcher}
+### `fetchers` {#input-fetchers}
 
-The global `fetch` function, to make network calls.
+An object to make network calls, containing:
+
+- `fetch`: An equivalent to the global `fetch` function
+- `octokit`: [GitHub Octokit](https://github.com/octokit/octokit.js?tab=readme-ov-file#octokit-api-client) that uses the `fetch` internally
 
 For example, an Input that retrieves a random Cat fact:
 
@@ -126,8 +129,8 @@ For example, an Input that retrieves a random Cat fact:
 import { createInput } from "create";
 
 export const inputCatFact = createInput({
-	async produce({ fetcher }) {
-		const response = await fetcher("https://catfact.ninja/fact");
+	async produce({ fetchers }) {
+		const response = await fetchers.fetch("https://catfact.ninja/fact");
 		const data = (await response.json()) as { fact: string };
 
 		return data.fact;
@@ -217,10 +220,10 @@ Doing so just makes that data easier to [mock out in tests](../testing/inputs) l
 
 The Context object provided to [producer APIs](../apis/producers).
 
-### `fetcher` {#system-fetcher}
+### `fetchers` {#system-fetchers}
 
 The global `fetch` function, to make network calls.
-This is the same as [Input Contexts' `fetcher`](#input-fetcher).
+This is the same as [Input Contexts' `fetchers`](#input-fetchers).
 
 ### `fs` {#system-fs}
 

--- a/packages/site/src/content/docs/engine/runtime/creations.mdx
+++ b/packages/site/src/content/docs/engine/runtime/creations.mdx
@@ -107,8 +107,8 @@ Each request may be specified as an object with:
 
 - `id` (`string`): Unique ID to know how to deduplicate previous creations during [merging](./merging#requests)
 - `send` (function): Asynchronous method that sends the request, which receives an object parameter containing:
-  - `fetcher`: Equivalent to the global `fetch`
-  - `octokit`: [GitHub Octokit](https://github.com/octokit/octokit.js?tab=readme-ov-file#octokit-api-client) that uses the `fetcher` internally
+  - `fetch`: Equivalent to the global `fetch`
+  - `octokit`: [GitHub Octokit](https://github.com/octokit/octokit.js?tab=readme-ov-file#octokit-api-client) that uses the `fetch` internally
 
 For example, this Block sets a GitHub repository's default branch to `main`:
 

--- a/packages/site/src/content/docs/engine/runtime/inputs.mdx
+++ b/packages/site/src/content/docs/engine/runtime/inputs.mdx
@@ -13,7 +13,7 @@ The kinds of dynamic data sourced by Inputs often include:
 - Sending network requests
 - Running terminal commands, such as `npm whoami`
 
-`create` will manage providing inputs with a runtime [Context](../runtime/contexts) containing a file system, network fetcher, and shell runner.
+`create` will manage providing inputs with a runtime [Context](../runtime/contexts) containing a file system, network fetchers, and shell runner.
 
 ## Production
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #46
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds an `--offline` CLI flag and corresponding `offline?: boolean` setting to APIs. When specified:
* System fetchers throw an error instead of making a request
* In `run*`, `creation.requests` is not executed

Also finishes a couple of non-user-facing cleanups while I'm in the areas:

* Removes shortcode CLI docs, since they don't actually exist
* Standardizes `produce*` and `run*` as taking in a value and a settings object, where the settings object is typed as `(Produce|Run)*Settings`
* Updates docs to reflect switching context `fetcher` to `fetchers`

💝 