### PR TITLE
feat: visualize errors on the CLI

### DIFF
--- a/packages/create/src/cli/initialize/runModeInitialize.test.ts
+++ b/packages/create/src/cli/initialize/runModeInitialize.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import { createBase } from "../../creators/createBase.js";
 import { createTemplate } from "../../creators/createTemplate.js";
+import { ClackDisplay } from "../display/createClackDisplay.js";
 import { CLIStatus } from "../status.js";
 import { runModeInitialize } from "./runModeInitialize.js";
 
@@ -41,15 +42,6 @@ vi.mock("../createInitialCommit.js", () => ({
 
 vi.mock("../clearLocalGitTags.js", () => ({
 	clearLocalGitTags: vi.fn(),
-}));
-
-vi.mock("../display/createClackDisplay.js", () => ({
-	createClackDisplay: () => ({
-		spinner: {
-			start: vi.fn(),
-			stop: vi.fn(),
-		},
-	}),
 }));
 
 const mockTryImportTemplatePreset = vi.fn();
@@ -96,6 +88,17 @@ vi.mock("./createTrackingBranches.js", () => ({
 	createTrackingBranches: vi.fn(),
 }));
 
+const display: ClackDisplay = {
+	dumpItems: vi.fn(),
+	item: vi.fn(),
+	log: vi.fn(),
+	spinner: {
+		message: vi.fn(),
+		start: vi.fn(),
+		stop: vi.fn(),
+	},
+};
+
 const base = createBase({
 	options: {},
 });
@@ -113,6 +116,7 @@ describe("runModeInitialize", () => {
 	it("returns an error when there is no from", async () => {
 		const actual = await runModeInitialize({
 			args: ["node", "create"],
+			display,
 		});
 
 		expect(actual).toEqual({
@@ -128,6 +132,7 @@ describe("runModeInitialize", () => {
 
 		const actual = await runModeInitialize({
 			args: ["node", "create", "my-app"],
+			display,
 		});
 
 		expect(actual).toEqual({
@@ -141,6 +146,7 @@ describe("runModeInitialize", () => {
 
 		const actual = await runModeInitialize({
 			args: ["node", "create", "my-app"],
+			display,
 		});
 
 		expect(actual).toEqual({ status: CLIStatus.Cancelled });
@@ -152,6 +158,7 @@ describe("runModeInitialize", () => {
 
 		const actual = await runModeInitialize({
 			args: ["node", "create", "my-app"],
+			display,
 		});
 
 		expect(actual).toEqual({ status: CLIStatus.Cancelled });
@@ -164,6 +171,7 @@ describe("runModeInitialize", () => {
 
 		const actual = await runModeInitialize({
 			args: ["node", "create", "my-app"],
+			display,
 		});
 
 		expect(actual).toEqual({ status: CLIStatus.Cancelled });
@@ -182,6 +190,7 @@ describe("runModeInitialize", () => {
 
 		const actual = await runModeInitialize({
 			args: ["node", "create", "my-app"],
+			display,
 		});
 
 		expect(actual).toEqual({ outro: message, status: CLIStatus.Error });
@@ -201,9 +210,7 @@ describe("runModeInitialize", () => {
 			suggestions,
 		});
 
-		await runModeInitialize({
-			args: ["node", "create", "my-app"],
-		});
+		await runModeInitialize({ args: ["node", "create", "my-app"], display });
 
 		expect(mockCreateRepositoryOnGitHub).toHaveBeenCalled();
 		expect(mockMessage.mock.calls).toMatchInlineSnapshot(`
@@ -239,6 +246,7 @@ describe("runModeInitialize", () => {
 
 		await runModeInitialize({
 			args: ["node", "create", "my-app"],
+			display,
 			offline: true,
 		});
 
@@ -276,6 +284,7 @@ describe("runModeInitialize", () => {
 
 		const actual = await runModeInitialize({
 			args: ["node", "create", "my-app"],
+			display,
 		});
 
 		expect(actual).toEqual({
@@ -302,6 +311,7 @@ describe("runModeInitialize", () => {
 
 		const actual = await runModeInitialize({
 			args: ["node", "create", "my-app"],
+			display,
 		});
 
 		expect(actual).toEqual({

--- a/packages/create/src/cli/initialize/runModeInitialize.ts
+++ b/packages/create/src/cli/initialize/runModeInitialize.ts
@@ -5,7 +5,7 @@ import { runPreset } from "../../runners/runPreset.js";
 import { createSystemContextWithAuth } from "../../system/createSystemContextWithAuth.js";
 import { clearLocalGitTags } from "../clearLocalGitTags.js";
 import { createInitialCommit } from "../createInitialCommit.js";
-import { createClackDisplay } from "../display/createClackDisplay.js";
+import { ClackDisplay } from "../display/createClackDisplay.js";
 import { runSpinnerTask } from "../display/runSpinnerTask.js";
 import { findPositionalFrom } from "../findPositionalFrom.js";
 import { tryImportTemplatePreset } from "../importers/tryImportTemplatePreset.js";
@@ -23,6 +23,7 @@ import { createTrackingBranches } from "./createTrackingBranches.js";
 export interface RunModeInitializeSettings {
 	args: string[];
 	directory?: string;
+	display: ClackDisplay;
 	from?: string;
 	offline?: boolean;
 	owner?: string;
@@ -34,6 +35,7 @@ export async function runModeInitialize({
 	args,
 	repository,
 	directory: requestedDirectory = repository,
+	display,
 	from = findPositionalFrom(args),
 	offline,
 	preset: requestedPreset,
@@ -83,7 +85,6 @@ export async function runModeInitialize({
 		};
 	}
 
-	const display = createClackDisplay();
 	const system = await createSystemContextWithAuth({
 		directory,
 		display,

--- a/packages/create/src/cli/loggers/logOutro.ts
+++ b/packages/create/src/cli/loggers/logOutro.ts
@@ -1,6 +1,29 @@
 import * as prompts from "@clack/prompts";
+import chalk from "chalk";
 
-export function logOutro(message: string, suggestions?: string[]) {
+import { SystemItemsDump } from "../display/createClackDisplay.js";
+
+export interface OutroErrata {
+	items?: SystemItemsDump;
+	suggestions?: string[];
+}
+
+export function logOutro(
+	message: string,
+	{ items, suggestions }: OutroErrata = {},
+) {
+	if (items) {
+		for (const [group, groupItems] of Object.entries(items)) {
+			for (const [id, item] of Object.entries(groupItems)) {
+				if (item.error) {
+					prompts.log.warn(
+						`The ${chalk.red(id)} ${group} failed. You should re-run it and fix its complaints.`,
+					);
+				}
+			}
+		}
+	}
+
 	prompts.outro(message);
 
 	if (suggestions?.length) {

--- a/packages/create/src/cli/migrate/runModeMigrate.test.ts
+++ b/packages/create/src/cli/migrate/runModeMigrate.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { createBase } from "../../creators/createBase.js";
+import { ClackDisplay } from "../display/createClackDisplay.js";
 import { CLIStatus } from "../status.js";
 import { runModeMigrate } from "./runModeMigrate.js";
 
@@ -36,15 +37,6 @@ vi.mock("../../system/createSystemContextWithAuth.js", () => ({
 	get createSystemContextWithAuth() {
 		return vi.fn().mockResolvedValue(mockSystem);
 	},
-}));
-
-vi.mock("../display/createClackDisplay.js", () => ({
-	createClackDisplay: () => ({
-		spinner: {
-			start: vi.fn(),
-			stop: vi.fn(),
-		},
-	}),
 }));
 
 const mockPromptForBaseOptions = vi.fn();
@@ -103,6 +95,17 @@ vi.mock("./parseMigrationSource.js", () => ({
 	},
 }));
 
+const display: ClackDisplay = {
+	dumpItems: vi.fn(),
+	item: vi.fn(),
+	log: vi.fn(),
+	spinner: {
+		message: vi.fn(),
+		start: vi.fn(),
+		stop: vi.fn(),
+	},
+};
+
 const base = createBase({
 	options: {},
 	template: {
@@ -122,7 +125,11 @@ describe("runModeMigrate", () => {
 
 		mockParseMigrationSource.mockReturnValueOnce(error);
 
-		const actual = await runModeMigrate({ args: [], configFile: undefined });
+		const actual = await runModeMigrate({
+			args: [],
+			configFile: undefined,
+			display,
+		});
 
 		expect(actual).toEqual({
 			outro: error.message,
@@ -137,7 +144,11 @@ describe("runModeMigrate", () => {
 			load: () => Promise.resolve(error),
 		});
 
-		const actual = await runModeMigrate({ args: [], configFile: undefined });
+		const actual = await runModeMigrate({
+			args: [],
+			configFile: undefined,
+			display,
+		});
 
 		expect(actual).toEqual({
 			outro: error.message,
@@ -150,7 +161,11 @@ describe("runModeMigrate", () => {
 			load: () => Promise.resolve(mockCancel),
 		});
 
-		const actual = await runModeMigrate({ args: [], configFile: undefined });
+		const actual = await runModeMigrate({
+			args: [],
+			configFile: undefined,
+			display,
+		});
 
 		expect(actual).toEqual({
 			status: CLIStatus.Cancelled,
@@ -163,7 +178,11 @@ describe("runModeMigrate", () => {
 		});
 		mockPromptForBaseOptions.mockResolvedValueOnce(mockCancel);
 
-		const actual = await runModeMigrate({ args: [], configFile: undefined });
+		const actual = await runModeMigrate({
+			args: [],
+			configFile: undefined,
+			display,
+		});
 
 		expect(actual).toEqual({
 			status: CLIStatus.Cancelled,
@@ -180,7 +199,11 @@ describe("runModeMigrate", () => {
 		mockGetForkedTemplateLocator.mockResolvedValueOnce(undefined);
 		mockApplyArgsToSettings.mockReturnValueOnce(new Error(message));
 
-		const actual = await runModeMigrate({ args: [], configFile: undefined });
+		const actual = await runModeMigrate({
+			args: [],
+			configFile: undefined,
+			display,
+		});
 
 		expect(actual).toEqual({ outro: message, status: CLIStatus.Error });
 	});
@@ -192,7 +215,11 @@ describe("runModeMigrate", () => {
 		mockPromptForBaseOptions.mockResolvedValueOnce({});
 		mockGetForkedTemplateLocator.mockResolvedValueOnce(undefined);
 
-		const actual = await runModeMigrate({ args: [], configFile: undefined });
+		const actual = await runModeMigrate({
+			args: [],
+			configFile: undefined,
+			display,
+		});
 
 		expect(actual).toEqual({
 			outro: "Done. Enjoy your updated repository! 💝",
@@ -214,7 +241,11 @@ describe("runModeMigrate", () => {
 			repository: "",
 		});
 
-		const actual = await runModeMigrate({ args: [], configFile: undefined });
+		const actual = await runModeMigrate({
+			args: [],
+			configFile: undefined,
+			display,
+		});
 
 		expect(actual).toEqual({
 			outro: "Done. Enjoy your new repository! 💝",
@@ -251,6 +282,7 @@ describe("runModeMigrate", () => {
 		const actual = await runModeMigrate({
 			args: [],
 			configFile: undefined,
+			display,
 			offline: true,
 		});
 

--- a/packages/create/src/cli/migrate/runModeMigrate.ts
+++ b/packages/create/src/cli/migrate/runModeMigrate.ts
@@ -5,7 +5,7 @@ import { runPreset } from "../../runners/runPreset.js";
 import { createSystemContextWithAuth } from "../../system/createSystemContextWithAuth.js";
 import { clearLocalGitTags } from "../clearLocalGitTags.js";
 import { createInitialCommit } from "../createInitialCommit.js";
-import { createClackDisplay } from "../display/createClackDisplay.js";
+import { ClackDisplay } from "../display/createClackDisplay.js";
 import { runSpinnerTask } from "../display/runSpinnerTask.js";
 import { findPositionalFrom } from "../findPositionalFrom.js";
 import { applyArgsToSettings } from "../parsers/applyArgsToSettings.js";
@@ -21,6 +21,7 @@ export interface RunModeMigrateSettings {
 	args: string[];
 	configFile: string | undefined;
 	directory?: string;
+	display: ClackDisplay;
 	from?: string;
 	offline?: boolean;
 	preset?: string | undefined;
@@ -30,6 +31,7 @@ export async function runModeMigrate({
 	args,
 	configFile,
 	directory = ".",
+	display,
 	from = findPositionalFrom(args),
 	offline,
 	preset: requestedPreset,
@@ -72,7 +74,6 @@ export async function runModeMigrate({
 	}
 
 	const { preset, settings } = loaded;
-	const display = createClackDisplay();
 	const system = await createSystemContextWithAuth({
 		directory,
 		display,

--- a/packages/create/src/cli/parsers/parseZodArgs.ts
+++ b/packages/create/src/cli/parsers/parseZodArgs.ts
@@ -7,6 +7,7 @@
 
 import { parseArgs, ParseArgsConfig } from "util";
 import {
+	z,
 	ZodBooleanDef,
 	ZodFirstPartyTypeKind,
 	ZodLiteralDef,
@@ -53,6 +54,7 @@ function zodValueToArgsOption(
 				type: zodValueTypeToArgsOptionType(zodValue._def),
 			};
 
+		case "ZodDefault":
 		case "ZodOptional":
 			return zodValueToArgsOption(key, zodValue._def.innerType);
 

--- a/packages/create/src/cli/parsers/parseZodArgs.ts
+++ b/packages/create/src/cli/parsers/parseZodArgs.ts
@@ -7,7 +7,6 @@
 
 import { parseArgs, ParseArgsConfig } from "util";
 import {
-	z,
 	ZodBooleanDef,
 	ZodFirstPartyTypeKind,
 	ZodLiteralDef,

--- a/packages/create/src/cli/runCli.test.ts
+++ b/packages/create/src/cli/runCli.test.ts
@@ -19,6 +19,18 @@ vi.mock("../packageData.js", () => ({
 	},
 }));
 
+const mockDisplay = {
+	dumpItems: vi.fn(),
+	spinner: {
+		start: vi.fn(),
+		stop: vi.fn(),
+	},
+};
+
+vi.mock("./display/createClackDisplay.js", () => ({
+	createClackDisplay: () => mockDisplay,
+}));
+
 const mockRunModeInitialize = vi.fn();
 
 vi.mock("./initialize/runModeInitialize.js", () => ({
@@ -117,7 +129,10 @@ describe("readProductionSettings", () => {
 		const actual = await runCli(args);
 
 		expect(actual).toEqual(status);
-		expect(mockRunModeInitialize).toHaveBeenCalledWith({ args });
+		expect(mockRunModeInitialize).toHaveBeenCalledWith({
+			args,
+			display: mockDisplay,
+		});
 		expect(mockRunModeMigrate).not.toHaveBeenCalled();
 	});
 
@@ -135,7 +150,11 @@ describe("readProductionSettings", () => {
 		const actual = await runCli(args);
 
 		expect(actual).toEqual(status);
-		expect(mockRunModeMigrate).toHaveBeenCalledWith({ args, configFile });
+		expect(mockRunModeMigrate).toHaveBeenCalledWith({
+			args,
+			configFile,
+			display: mockDisplay,
+		});
 		expect(mockRunModeInitialize).not.toHaveBeenCalled();
 	});
 
@@ -148,7 +167,7 @@ describe("readProductionSettings", () => {
 
 		await runCli(["typescript-app"]);
 
-		expect(mockLogOutro).toHaveBeenCalledWith(outro, suggestions);
+		expect(mockLogOutro).toHaveBeenCalledWith(outro, { suggestions });
 	});
 
 	it("logs a cancellation outro when one is not resolved by the mode runner", async () => {
@@ -161,7 +180,7 @@ describe("readProductionSettings", () => {
 
 		expect(mockLogOutro).toHaveBeenCalledWith(
 			chalk.yellow("Operation cancelled. Exiting - maybe another time? 👋"),
-			suggestions,
+			{ suggestions },
 		);
 	});
 });

--- a/packages/create/src/cli/runCli.ts
+++ b/packages/create/src/cli/runCli.ts
@@ -103,6 +103,7 @@ export async function runCli(args: string[]) {
 	}
 
 	const display = createClackDisplay();
+	console.log({ display });
 	const sharedSettings = {
 		...validatedValues,
 		args,

--- a/packages/create/src/cli/runCli.ts
+++ b/packages/create/src/cli/runCli.ts
@@ -4,6 +4,7 @@ import { parseArgs } from "node:util";
 import { z } from "zod";
 
 import { packageData } from "../packageData.js";
+import { createClackDisplay } from "./display/createClackDisplay.js";
 import { runModeInitialize } from "./initialize/runModeInitialize.js";
 import { logHelpText } from "./loggers/logHelpText.js";
 import { logOutro } from "./loggers/logOutro.js";
@@ -101,19 +102,25 @@ export async function runCli(args: string[]) {
 		return CLIStatus.Success;
 	}
 
+	const display = createClackDisplay();
+	const sharedSettings = {
+		...validatedValues,
+		args,
+		display,
+	};
+
 	const { outro, status, suggestions } =
 		productionSettings.mode === "initialize"
-			? await runModeInitialize({ ...validatedValues, args })
+			? await runModeInitialize(sharedSettings)
 			: await runModeMigrate({
-					...validatedValues,
-					args,
+					...sharedSettings,
 					configFile: productionSettings.configFile,
 				});
 
 	logOutro(
 		outro ??
 			chalk.yellow("Operation cancelled. Exiting - maybe another time? 👋"),
-		suggestions,
+		{ items: display.dumpItems(), suggestions },
 	);
 
 	return status;

--- a/packages/create/src/runners/applyRequestsToSystem.test.ts
+++ b/packages/create/src/runners/applyRequestsToSystem.test.ts
@@ -33,9 +33,9 @@ describe("applyRequestsToSystem", () => {
 		);
 
 		expect(system.display.item.mock.calls).toEqual([
-			["requests", id, { start: expect.any(Number) }],
-			["requests", id, { error }],
-			["requests", id, { end: expect.any(Number) }],
+			["request", id, { start: expect.any(Number) }],
+			["request", id, { error }],
+			["request", id, { end: expect.any(Number) }],
 		]);
 	});
 });

--- a/packages/create/src/runners/applyRequestsToSystem.ts
+++ b/packages/create/src/runners/applyRequestsToSystem.ts
@@ -7,15 +7,15 @@ export async function applyRequestsToSystem(
 ) {
 	await Promise.all(
 		requests.map(async (request) => {
-			system.display.item("requests", request.id, { start: Date.now() });
+			system.display.item("request", request.id, { start: Date.now() });
 
 			try {
 				await request.send(system.fetchers);
 			} catch (error) {
-				system.display.item("requests", request.id, { error });
+				system.display.item("request", request.id, { error });
 			}
 
-			system.display.item("requests", request.id, { end: Date.now() });
+			system.display.item("request", request.id, { end: Date.now() });
 		}),
 	);
 }

--- a/packages/create/src/runners/applyScriptsToSystem.test.ts
+++ b/packages/create/src/runners/applyScriptsToSystem.test.ts
@@ -23,9 +23,9 @@ describe("applyCommandsToSystem", () => {
 		await applyScriptsToSystem([command], system);
 
 		expect(system.display.item.mock.calls).toEqual([
-			["scripts", command, { start: expect.any(Number) }],
-			["scripts", command, { end: expect.any(Number) }],
-			["scripts", command, { error }],
+			["script", command, { start: expect.any(Number) }],
+			["script", command, { end: expect.any(Number) }],
+			["script", command, { error }],
 		]);
 	});
 
@@ -39,9 +39,9 @@ describe("applyCommandsToSystem", () => {
 		await applyScriptsToSystem([{ commands: [command], phase: 0 }], system);
 
 		expect(system.display.item.mock.calls).toEqual([
-			["scripts", command, { start: expect.any(Number) }],
-			["scripts", command, { end: expect.any(Number) }],
-			["scripts", command, { error }],
+			["script", command, { start: expect.any(Number) }],
+			["script", command, { end: expect.any(Number) }],
+			["script", command, { error }],
 		]);
 	});
 

--- a/packages/create/src/runners/applyScriptsToSystem.ts
+++ b/packages/create/src/runners/applyScriptsToSystem.ts
@@ -19,12 +19,12 @@ export async function applyScriptsToSystem(
 		.sort();
 
 	async function runCommand(command: string) {
-		system.display.item("scripts", command, { start: Date.now() });
+		system.display.item("script", command, { start: Date.now() });
 		const result = await system.runner(command);
-		system.display.item("scripts", command, { end: Date.now() });
+		system.display.item("script", command, { end: Date.now() });
 
 		if (result instanceof Error) {
-			system.display.item("scripts", command, { error: result });
+			system.display.item("script", command, { error: result });
 		}
 	}
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #110
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Consolidates the existing `ClackDisplay` display to come from `runCli`, so its collected items can be passed to `logOutro`.

Example output:

```plaintext
◇  Prepared local repository
│
│  Great, you've got a new repository ready to use in:
│    ./my-typescript-app
│
▲  The exit 1 script errored. You might want to re-run it.
│
└  Thanks for using create! 💝
```

💝 