### PR TITLE
feat: handle errors in runPreset

### DIFF
--- a/packages/create/src/cli/display/runSpinnerTask.test.ts
+++ b/packages/create/src/cli/display/runSpinnerTask.test.ts
@@ -1,0 +1,65 @@
+import chalk from "chalk";
+import { describe, expect, it, vi } from "vitest";
+
+import { createClackDisplay } from "./createClackDisplay.js";
+import { runSpinnerTask } from "./runSpinnerTask.js";
+
+const mockLog = {
+	error: vi.fn(),
+};
+const mockSpinner = {
+	start: vi.fn(),
+	stop: vi.fn(),
+};
+
+vi.mock("@clack/prompts", () => ({
+	get log() {
+		return mockLog;
+	},
+	spinner: () => mockSpinner,
+}));
+
+describe("runSpinnerTask", () => {
+	it("displays the error when the task throws an error", async () => {
+		const error = new Error("Oh no!");
+
+		const actual = await runSpinnerTask(
+			createClackDisplay(),
+			"Running task",
+			"Ran task",
+			vi.fn().mockRejectedValueOnce(error),
+		);
+
+		expect(actual).toBe(error);
+		expect(mockLog.error).toHaveBeenCalledWith(chalk.red(error.stack));
+		expect(mockSpinner.stop.mock.calls).toMatchInlineSnapshot(`
+			[
+			  [
+			    "Error running task:",
+			    1,
+			  ],
+			]
+		`);
+	});
+
+	it("displays a general log when the task resolves with a value", async () => {
+		const expected = { ok: true };
+
+		const actual = await runSpinnerTask(
+			createClackDisplay(),
+			"Running task",
+			"Ran task",
+			vi.fn().mockResolvedValueOnce(expected),
+		);
+
+		expect(actual).toBe(expected);
+		expect(mockLog.error).not.toHaveBeenCalled();
+		expect(mockSpinner.stop.mock.calls).toMatchInlineSnapshot(`
+			[
+			  [
+			    "Ran task",
+			  ],
+			]
+		`);
+	});
+});

--- a/packages/create/src/cli/display/runSpinnerTask.ts
+++ b/packages/create/src/cli/display/runSpinnerTask.ts
@@ -1,3 +1,7 @@
+import * as prompts from "@clack/prompts";
+import chalk from "chalk";
+
+import { tryCatchError } from "../../utils/tryCatch.js";
 import { ClackDisplay } from "./createClackDisplay.js";
 
 export async function runSpinnerTask<T>(
@@ -8,9 +12,17 @@ export async function runSpinnerTask<T>(
 ) {
 	display.spinner.start(`${start}...`);
 
-	const result = await task();
+	const result = await tryCatchError(task());
 
-	display.spinner.stop(`${stop}.`);
+	if (result instanceof Error) {
+		display.spinner.stop(
+			`Error ${start[0].toLowerCase()}${start.slice(1)}:`,
+			1,
+		);
+		prompts.log.error(chalk.red(result.stack));
+	} else {
+		display.spinner.stop(stop);
+	}
 
 	return result;
 }

--- a/packages/create/src/cli/initialize/runModeInitialize.ts
+++ b/packages/create/src/cli/initialize/runModeInitialize.ts
@@ -126,6 +126,12 @@ export async function runModeInitialize({
 				options,
 			}),
 	);
+	if (creation instanceof Error) {
+		return {
+			outro: `Leaving changes to the local directory on disk. 👋`,
+			status: CLIStatus.Error,
+		};
+	}
 
 	await runSpinnerTask(
 		display,

--- a/packages/create/src/cli/migrate/runModeMigrate.ts
+++ b/packages/create/src/cli/migrate/runModeMigrate.ts
@@ -109,11 +109,11 @@ export async function runModeMigrate({
 		return { outro: mergedSettings.message, status: CLIStatus.Error };
 	}
 
-	await runSpinnerTask(
+	const creation = await runSpinnerTask(
 		display,
 		`Running the ${preset.about.name} preset`,
 		`Ran the ${preset.about.name} preset`,
-		async () => {
+		async () =>
 			await runPreset(preset, {
 				...mergedSettings,
 				...system,
@@ -121,9 +121,14 @@ export async function runModeMigrate({
 				mode: "migrate",
 				offline,
 				options,
-			});
-		},
+			}),
 	);
+	if (creation instanceof Error) {
+		return {
+			outro: `Leaving changes to the local directory on disk. 👋`,
+			status: CLIStatus.Error,
+		};
+	}
 
 	if (templateLocator) {
 		await runSpinnerTask(

--- a/packages/create/src/cli/tryImportWithPredicate.ts
+++ b/packages/create/src/cli/tryImportWithPredicate.ts
@@ -6,9 +6,7 @@ export async function tryImportWithPredicate<T>(
 	predicate: (value: unknown) => value is T,
 	typeName: string,
 ): Promise<Error | T> {
-	const templateModule = (await tryCatchError(importer(moduleName))) as
-		| Error
-		| object;
+	const templateModule = await tryCatchError(importer(moduleName));
 	if (templateModule instanceof Error) {
 		return templateModule;
 	}

--- a/packages/create/src/utils/tryCatch.ts
+++ b/packages/create/src/utils/tryCatch.ts
@@ -1,8 +1,8 @@
-export async function tryCatchError(promise: Promise<unknown>) {
+export async function tryCatchError<T>(promise: Promise<T>) {
 	try {
 		return await promise;
 	} catch (error) {
-		return error;
+		return error as Error;
 	}
 }
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #81
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds the nice wrapping logic to `runSpinnerTask` so any errors are caught nicely.

💝 