### PR TITLE
feat: add rerun suggestions to the CLI

### DIFF
--- a/packages/create/src/cli/importers/tryImportTemplatePreset.test.ts
+++ b/packages/create/src/cli/importers/tryImportTemplatePreset.test.ts
@@ -2,13 +2,10 @@ import { describe, expect, it, vi } from "vitest";
 
 import { tryImportTemplatePreset } from "./tryImportTemplatePreset.js";
 
-const mockCancel = Symbol("");
-const mockIsCancel = (value: unknown) => value === mockCancel;
+const mockCancel = Symbol("cancel");
 
 vi.mock("@clack/prompts", () => ({
-	get isCancel() {
-		return mockIsCancel;
-	},
+	isCancel: (value: unknown) => value === mockCancel,
 }));
 
 const mockPromptForPreset = vi.fn();

--- a/packages/create/src/cli/initialize/asCreationOptions.test.ts
+++ b/packages/create/src/cli/initialize/asCreationOptions.test.ts
@@ -1,16 +1,16 @@
 import { describe, expect, it } from "vitest";
 
-import { assertOptionsForInitialize } from "./assertOptionsForInitialize.js";
+import { asCreationOptions } from "./asCreationOptions.js";
 
 const owner = "TestOwner";
 const repository = "test-repository";
 
-describe("assertOptionsForInitialize", () => {
+describe("asCreationOptions", () => {
 	it("throws an error when the options are missing owner", () => {
 		const options = { repository };
 
 		expect(() => {
-			assertOptionsForInitialize(options);
+			asCreationOptions(options);
 		}).toThrowError(
 			`To run with --mode initialize, the Template must have a --owner Option of type string.`,
 		);
@@ -20,7 +20,7 @@ describe("assertOptionsForInitialize", () => {
 		const options = { owner: 123, repository };
 
 		expect(() => {
-			assertOptionsForInitialize(options);
+			asCreationOptions(options);
 		}).toThrowError(
 			`To run with --mode initialize, the Template must have a --owner Option of type string.`,
 		);
@@ -30,7 +30,7 @@ describe("assertOptionsForInitialize", () => {
 		const options = { owner };
 
 		expect(() => {
-			assertOptionsForInitialize(options);
+			asCreationOptions(options);
 		}).toThrowError(
 			`To run with --mode initialize, the Template must have a --repository Option of type string.`,
 		);
@@ -40,7 +40,7 @@ describe("assertOptionsForInitialize", () => {
 		const options = { owner, repository: 123 };
 
 		expect(() => {
-			assertOptionsForInitialize(options);
+			asCreationOptions(options);
 		}).toThrowError(
 			`To run with --mode initialize, the Template must have a --repository Option of type string.`,
 		);
@@ -49,8 +49,6 @@ describe("assertOptionsForInitialize", () => {
 	it("does not throw an error when the options have owner and repository", () => {
 		const options = { owner, repository };
 
-		expect(() => {
-			assertOptionsForInitialize(options);
-		}).not.toThrow();
+		expect(asCreationOptions(options)).toBe(options);
 	});
 });

--- a/packages/create/src/cli/initialize/asCreationOptions.ts
+++ b/packages/create/src/cli/initialize/asCreationOptions.ts
@@ -3,9 +3,7 @@ export interface CreationOptions {
 	repository: string;
 }
 
-export function assertOptionsForInitialize(
-	options: object,
-): asserts options is CreationOptions {
+export function asCreationOptions(options: object): CreationOptions {
 	for (const key of ["owner", "repository"]) {
 		if (typeof (options as Record<string, unknown>)[key] !== "string") {
 			throw new Error(
@@ -13,4 +11,6 @@ export function assertOptionsForInitialize(
 			);
 		}
 	}
+
+	return options as CreationOptions;
 }

--- a/packages/create/src/cli/initialize/createRepositoryOnGitHub.ts
+++ b/packages/create/src/cli/initialize/createRepositoryOnGitHub.ts
@@ -1,7 +1,7 @@
 import { Octokit } from "octokit";
 
 import { RepositoryTemplate } from "../../types/bases.js";
-import { CreationOptions } from "./assertOptionsForInitialize.js";
+import { CreationOptions } from "./asCreationOptions.js";
 
 export async function createRepositoryOnGitHub(
 	{ owner, repository }: CreationOptions,

--- a/packages/create/src/cli/initialize/createTrackingBranches.ts
+++ b/packages/create/src/cli/initialize/createTrackingBranches.ts
@@ -1,5 +1,5 @@
 import { SystemRunner } from "../../types/system.js";
-import { CreationOptions } from "./assertOptionsForInitialize.js";
+import { CreationOptions } from "./asCreationOptions.js";
 
 export async function createTrackingBranches(
 	{ owner, repository }: CreationOptions,

--- a/packages/create/src/cli/loggers/logMigrateHelpText.test.ts
+++ b/packages/create/src/cli/loggers/logMigrateHelpText.test.ts
@@ -7,17 +7,14 @@ import { MigrationSource } from "../migrate/parseMigrationSource.js";
 import { CLIStatus } from "../status.js";
 import { logMigrateHelpText } from "./logMigrateHelpText.js";
 
-const mockCancel = Symbol("");
-const mockIsCancel = (value: unknown) => value === mockCancel;
+const mockCancel = Symbol("cancel");
 const mockSpinner = {
 	start: vi.fn(),
 	stop: vi.fn(),
 };
 
 vi.mock("@clack/prompts", () => ({
-	get isCancel() {
-		return mockIsCancel;
-	},
+	isCancel: (value: unknown) => value === mockCancel,
 	spinner: () => mockSpinner,
 }));
 

--- a/packages/create/src/cli/loggers/logRerunSuggestion.test.ts
+++ b/packages/create/src/cli/loggers/logRerunSuggestion.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, test, vi } from "vitest";
+
+import { logRerunSuggestion } from "./logRerunSuggestion.js";
+
+const mockLog = {
+	info: vi.fn(),
+};
+
+vi.mock("@clack/prompts", () => ({
+	get log() {
+		return mockLog;
+	},
+}));
+
+describe("logRerunSuggestion", () => {
+	it("does not log when there are no prompted entries", () => {
+		logRerunSuggestion(["my-app"], {});
+
+		expect(mockLog.info).not.toHaveBeenCalled();
+	});
+
+	it("logs when there are no prompted entries", () => {
+		logRerunSuggestion(["my-app"], { abc: "def" });
+
+		expect(mockLog.info).toHaveBeenCalled();
+	});
+
+	test("value stringification", () => {
+		logRerunSuggestion(["my-app"], {
+			"is-false": false,
+			"is-true": true,
+			multiple: ["def", 456],
+			numeric: 123,
+			spaced: "a bb ccc",
+			stringy: "abc",
+		});
+
+		expect(mockLog.info.mock.calls).toMatchInlineSnapshot(`
+			[
+			  [
+			    "Tip: to run again with the same input values, use: npx create my-app --is-false false --is-true --multiple def --multiple 456 --numeric 123 --spaced "a bb ccc" --stringy abc",
+			  ],
+			]
+		`);
+	});
+});

--- a/packages/create/src/cli/loggers/logRerunSuggestion.ts
+++ b/packages/create/src/cli/loggers/logRerunSuggestion.ts
@@ -1,0 +1,43 @@
+import * as prompts from "@clack/prompts";
+import chalk from "chalk";
+
+export function logRerunSuggestion(args: string[], prompted: object) {
+	const promptedEntries = Object.entries(prompted);
+	if (!promptedEntries.length) {
+		return;
+	}
+
+	prompts.log.info(
+		[
+			chalk.italic(`Tip: to run again with the same input values, use:`),
+			chalk.blue(
+				[
+					`npx create`,
+					...args,
+					promptedEntries
+
+						.map(([key, value]) => stringifyPair(key, value))
+						.join(" "),
+				].join(" "),
+			),
+		].join(" "),
+	);
+}
+
+function stringifyPair(key: string, value: unknown): string {
+	if (Array.isArray(value)) {
+		return value.map((element) => stringifyPair(key, element)).join(" ");
+	}
+
+	const flag = `--${key}`;
+
+	if (typeof value === "boolean" && value) {
+		return flag;
+	}
+
+	const valueStringified = String(value);
+
+	return valueStringified.includes(" ")
+		? `${flag} "${valueStringified}"`
+		: `${flag} ${valueStringified}`;
+}

--- a/packages/create/src/cli/parsers/applyArgsToSettings.ts
+++ b/packages/create/src/cli/parsers/applyArgsToSettings.ts
@@ -1,6 +1,7 @@
 import { CreateConfigSettings } from "../../config/types.js";
 import { AnyShape, InferredObject } from "../../options.js";
 import { Preset } from "../../types/presets.js";
+import { slugify } from "../utils.js";
 
 export function applyArgsToSettings<OptionsShape extends AnyShape>(
 	args: string[],
@@ -14,7 +15,7 @@ export function applyArgsToSettings<OptionsShape extends AnyShape>(
 			.filter((block) => block.about?.name)
 			.map((block) => [
 				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-				block.about!.name!.toLowerCase().replaceAll(/\W+/gu, "-"),
+				slugify(block.about!.name!),
 				block,
 			]),
 	);

--- a/packages/create/src/cli/prompts/promptForDirectory.test.ts
+++ b/packages/create/src/cli/prompts/promptForDirectory.test.ts
@@ -3,15 +3,12 @@ import { describe, expect, it, vi } from "vitest";
 import { createBase } from "../../creators/createBase.js";
 import { promptForDirectory } from "./promptForDirectory.js";
 
-const mockCancel = Symbol("");
-const mockIsCancel = (value: unknown) => value === mockCancel;
+const mockCancel = Symbol("cancel");
 const mockText = vi.fn();
 const mockWarn = vi.fn();
 
 vi.mock("@clack/prompts", () => ({
-	get isCancel() {
-		return mockIsCancel;
-	},
+	isCancel: (value: unknown) => value === mockCancel,
 	get log() {
 		return {
 			warn: mockWarn,

--- a/packages/create/src/cli/prompts/promptForDirectory.ts
+++ b/packages/create/src/cli/prompts/promptForDirectory.ts
@@ -2,6 +2,7 @@ import * as prompts from "@clack/prompts";
 import * as fs from "node:fs/promises";
 
 import { Template } from "../../types/templates.js";
+import { slugify } from "../utils.js";
 import { validateNewDirectory } from "./validators.js";
 
 export interface PromptForDirectorySettings {
@@ -25,9 +26,7 @@ export async function promptForDirectory({
 	}
 
 	const directory = await prompts.text({
-		initialValue:
-			template.about?.name &&
-			`my-${template.about.name.toLowerCase().replaceAll(" ", "-")}`,
+		initialValue: template.about?.name && `my-${slugify(template.about.name)}`,
 		message:
 			"What will the directory and name of the repository be? (--directory)",
 		validate: validateNewDirectory,

--- a/packages/create/src/cli/runCli.ts
+++ b/packages/create/src/cli/runCli.ts
@@ -65,8 +65,8 @@ export async function runCli(args: string[]) {
 
 	prompts.intro(
 		[
-			chalk.greenBright(`✨ `),
 			chalk.bgGreenBright.black(`create`),
+			chalk.greenBright(`✨ `),
 			chalk.greenBright(` ✨`),
 		].join(""),
 	);

--- a/packages/create/src/cli/runCli.ts
+++ b/packages/create/src/cli/runCli.ts
@@ -65,8 +65,8 @@ export async function runCli(args: string[]) {
 
 	prompts.intro(
 		[
-			chalk.bgGreenBright.black(`create`),
 			chalk.greenBright(`✨ `),
+			chalk.bgGreenBright.black(`create`),
 			chalk.greenBright(` ✨`),
 		].join(""),
 	);

--- a/packages/create/src/cli/utils.ts
+++ b/packages/create/src/cli/utils.ts
@@ -5,3 +5,7 @@ export function isLocalPath(from: string) {
 export function makeRelative(item: string) {
 	return item.startsWith(".") ? item : `./${item}`;
 }
+
+export function slugify(text: string) {
+	return text.toLowerCase().replaceAll(/\W+/gu, "-");
+}


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #119
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

The CTA rerun logic looked at all values and checked if they were different from the default. This simplifies the logic by (mostly) only looking at values that were prompted. The only exceptions are:
* `directory` and `repository`: since they come in before loading options
* `preset`: which still comes in before loading too, pending #39

Also includes a couple of internal refactors:
* Unified the slugification logic into a `slugify` function
* Streamlines `@clack/prompts` mocks a bit

💝 
