### PR TITLE
chore(vscode): disable implicit type checking of js files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,6 +15,6 @@
 	],
 	"eslint.rules.customizations": [{ "rule": "*", "severity": "warn" }],
 	"eslint.useFlatConfig": true,
-	"typescript.tsdk": "node_modules/typescript/lib",
-	"js/ts.implicitProjectConfig.checkJs": false
+	"js/ts.implicitProjectConfig.checkJs": false,
+	"typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,5 +15,6 @@
 	],
 	"eslint.rules.customizations": [{ "rule": "*", "severity": "warn" }],
 	"eslint.useFlatConfig": true,
-	"typescript.tsdk": "node_modules/typescript/lib"
+	"typescript.tsdk": "node_modules/typescript/lib",
+	"js/ts.implicitProjectConfig.checkJs": false
 }


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to create! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

This disables implicit typechecks in JS files which otherwise are not included in a `tsconfig.json` somewhere.

If a) the developer has enabled this setting globally, and b) the project has not yet been built, we will see type errors in any JS file referencing a dist dir (e.g., `lib/cli/runCli.js`)

If this requires me to create an issue, I can do so.

![Screenshot of VS Code showing a "Cannot find module '... .js' or its corresponding type declarations." error dropdown on a bin/index.js import from a .js file](https://github.com/user-attachments/assets/9cee565a-303c-48eb-b655-f5663f312607)

