### PR TITLE
fix: ensure get-github-auth-token@^0.1.1

### DIFF
--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -30,7 +30,7 @@
 		"chalk": "^5.4.1",
 		"create-fs": "workspace:^",
 		"execa": "^9.5.2",
-		"get-github-auth-token": "^0.1.0",
+		"get-github-auth-token": "^0.1.1",
 		"hash-object": "^5.0.1",
 		"hosted-git-info": "^8.0.2",
 		"import-local-or-npx": "^0.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,8 +123,8 @@ importers:
         specifier: ^9.5.2
         version: 9.5.2
       get-github-auth-token:
-        specifier: ^0.1.0
-        version: 0.1.0
+        specifier: ^0.1.1
+        version: 0.1.1
       hash-object:
         specifier: ^5.0.1
         version: 5.0.1
@@ -2409,8 +2409,8 @@ packages:
     resolution: {integrity: sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ==}
     engines: {node: '>=18'}
 
-  get-github-auth-token@0.1.0:
-    resolution: {integrity: sha512-ENm+A39AV0X4+Ls1jiCvmqx+C8hSYTv4d5hV9Ks+EL+gx9a0P9pYYpRE1k2ExwRT3EFQabGXF1Rkdp5FIsLkiw==}
+  get-github-auth-token@0.1.1:
+    resolution: {integrity: sha512-SifKYtFehQUVgeEBiTeQMGWeNfNx59gZ7GzYzD6vKCIGDh5YT+Axm5i0VgP0XaD8TeN8ABtp593eX+wSFk8IpQ==}
     engines: {node: '>=18'}
 
   get-stdin@9.0.0:
@@ -6781,7 +6781,7 @@ snapshots:
 
   get-east-asian-width@1.3.0: {}
 
-  get-github-auth-token@0.1.0: {}
+  get-github-auth-token@0.1.1: {}
 
   get-stdin@9.0.0: {}
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #146
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

My suspicion was right: this was due to an old version. The latest `get-github-auth-token@0.1.1` includes https://github.com/JoshuaKGoldberg/get-github-auth-token/pull/365 and should be matched by `^0.1.0`. But if a system has the old version cached -or otherwise resolves to `0.1.0` specifically- the crash will show up in `create`.

💝 