### PR TITLE
feat: require user confirmation or --yes to install package with npx

### DIFF
--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -33,7 +33,7 @@
 		"get-github-auth-token": "^0.1.1",
 		"hash-object": "^5.0.1",
 		"hosted-git-info": "^8.0.2",
-		"import-local-or-npx": "^0.2.0",
+		"import-local-or-npx": "^0.3.0",
 		"octokit": "^4.1.0",
 		"prettier": "3.4.2",
 		"read-pkg": "^9.0.1",

--- a/packages/create/src/cli/importers/createNpxInstallationConfirm.test.ts
+++ b/packages/create/src/cli/importers/createNpxInstallationConfirm.test.ts
@@ -1,0 +1,94 @@
+import chalk from "chalk";
+import { describe, expect, it, vi } from "vitest";
+
+import { ClackSpinner } from "../display/createClackDisplay.js";
+import { createNpxInstallationConfirm } from "./createNpxInstallationConfirm.js";
+
+const createSpinner = () => ({
+	message: vi.fn(),
+	start: vi.fn(),
+	stop: vi.fn(),
+});
+
+const mockConfirm = vi.fn();
+
+vi.mock("@clack/prompts", () => ({
+	confirm: () => mockConfirm,
+}));
+
+describe("createNpxInstallationConfirm", () => {
+	it("resolves with undefined without confirming if yes is true", async () => {
+		const spinner = createSpinner();
+
+		const actual = await createNpxInstallationConfirm(
+			"../create-my-app",
+			spinner,
+			true,
+		)();
+
+		expect(actual).toBe(undefined);
+		expect(mockConfirm).not.toHaveBeenCalled();
+		expect(spinner.start.mock.calls).toMatchInlineSnapshot(`
+			[
+			  [
+			    "Loading ../create-my-app",
+			  ],
+			]
+		`);
+		expect(spinner.stop.mock.calls).toMatchInlineSnapshot(`
+			[
+			  [
+			    "../create-my-app not found locally and --yes specified. ../create-my-app will be fetched with npx. ",
+			  ],
+			]
+		`);
+	});
+
+	it("resolves with an error if yes is false and the confirm prompt is not accepted", async () => {
+		const spinner = createSpinner();
+		mockConfirm.mockResolvedValueOnce(false);
+
+		const actual = await createNpxInstallationConfirm(
+			"../create-my-app",
+			spinner,
+			false,
+		)();
+
+		expect(actual).toEqual(new Error("Installation cancelled."));
+		expect(spinner.start.mock.calls).toMatchInlineSnapshot(`[]`);
+		expect(spinner.stop.mock.calls).toMatchInlineSnapshot(`
+			[
+			  [
+			    "../create-my-app not found locally and --yes not specified. ../create-my-app will need to be fetched with npx. ",
+			  ],
+			]
+		`);
+	});
+
+	it("resolves with undefined if yes is false and the confirm prompt is accepted", async () => {
+		const spinner = createSpinner();
+		mockConfirm.mockResolvedValueOnce(false);
+
+		const actual = await createNpxInstallationConfirm(
+			"../create-my-app",
+			spinner,
+			true,
+		)();
+
+		expect(actual).toEqual(undefined);
+		expect(spinner.start.mock.calls).toMatchInlineSnapshot(`
+			[
+			  [
+			    "Loading ../create-my-app",
+			  ],
+			]
+		`);
+		expect(spinner.stop.mock.calls).toMatchInlineSnapshot(`
+			[
+			  [
+			    "../create-my-app not found locally and --yes specified. ../create-my-app will be fetched with npx. ",
+			  ],
+			]
+		`);
+	});
+});

--- a/packages/create/src/cli/importers/createNpxInstallationConfirm.test.ts
+++ b/packages/create/src/cli/importers/createNpxInstallationConfirm.test.ts
@@ -1,7 +1,5 @@
-import chalk from "chalk";
 import { describe, expect, it, vi } from "vitest";
 
-import { ClackSpinner } from "../display/createClackDisplay.js";
 import { createNpxInstallationConfirm } from "./createNpxInstallationConfirm.js";
 
 const createSpinner = () => ({
@@ -13,7 +11,9 @@ const createSpinner = () => ({
 const mockConfirm = vi.fn();
 
 vi.mock("@clack/prompts", () => ({
-	confirm: () => mockConfirm,
+	get confirm() {
+		return mockConfirm;
+	},
 }));
 
 describe("createNpxInstallationConfirm", () => {
@@ -55,6 +55,15 @@ describe("createNpxInstallationConfirm", () => {
 		)();
 
 		expect(actual).toEqual(new Error("Installation cancelled."));
+		expect(mockConfirm.mock.calls).toMatchInlineSnapshot(`
+			[
+			  [
+			    {
+			      "message": "Ok to proceed?",
+			    },
+			  ],
+			]
+		`);
 		expect(spinner.start.mock.calls).toMatchInlineSnapshot(`[]`);
 		expect(spinner.stop.mock.calls).toMatchInlineSnapshot(`
 			[
@@ -67,15 +76,24 @@ describe("createNpxInstallationConfirm", () => {
 
 	it("resolves with undefined if yes is false and the confirm prompt is accepted", async () => {
 		const spinner = createSpinner();
-		mockConfirm.mockResolvedValueOnce(false);
+		mockConfirm.mockResolvedValueOnce(true);
 
 		const actual = await createNpxInstallationConfirm(
 			"../create-my-app",
 			spinner,
-			true,
+			false,
 		)();
 
 		expect(actual).toEqual(undefined);
+		expect(mockConfirm.mock.calls).toMatchInlineSnapshot(`
+			[
+			  [
+			    {
+			      "message": "Ok to proceed?",
+			    },
+			  ],
+			]
+		`);
 		expect(spinner.start.mock.calls).toMatchInlineSnapshot(`
 			[
 			  [
@@ -86,7 +104,7 @@ describe("createNpxInstallationConfirm", () => {
 		expect(spinner.stop.mock.calls).toMatchInlineSnapshot(`
 			[
 			  [
-			    "../create-my-app not found locally and --yes specified. ../create-my-app will be fetched with npx. ",
+			    "../create-my-app not found locally and --yes not specified. ../create-my-app will need to be fetched with npx. ",
 			  ],
 			]
 		`);

--- a/packages/create/src/cli/importers/createNpxInstallationConfirm.ts
+++ b/packages/create/src/cli/importers/createNpxInstallationConfirm.ts
@@ -1,0 +1,34 @@
+import * as prompts from "@clack/prompts";
+import chalk from "chalk";
+
+import { ClackSpinner } from "../display/createClackDisplay.js";
+
+export function createNpxInstallationConfirm(
+	from: string,
+	spinner: ClackSpinner,
+	yes: boolean | undefined,
+) {
+	return async () => {
+		if (yes) {
+			spinner.stop(
+				`${chalk.blue(from)} not found locally and ${chalk.blue("--yes")} specified. ${from} will be fetched with npx. `,
+			);
+			spinner.start(`Loading ${chalk.blue(from)}`);
+			return undefined;
+		}
+
+		spinner.stop(
+			`${chalk.blue(from)} not found locally and ${chalk.blue("--yes")} not specified. ${from} will need to be fetched with npx. `,
+		);
+
+		const allowed = await prompts.confirm({
+			message: `Ok to proceed?`,
+		});
+
+		if (allowed !== true) {
+			return new Error("Installation cancelled.");
+		}
+
+		spinner.start(`Loading ${chalk.blue(from)}`);
+	};
+}

--- a/packages/create/src/cli/importers/tryImportAndInstallIfNecessary.test.ts
+++ b/packages/create/src/cli/importers/tryImportAndInstallIfNecessary.test.ts
@@ -1,6 +1,16 @@
+import chalk from "chalk";
 import { describe, expect, it, vi } from "vitest";
 
 import { tryImportAndInstallIfNecessary } from "./tryImportAndInstallIfNecessary.js";
+
+const mockSpinner = {
+	start: vi.fn(),
+	stop: vi.fn(),
+};
+
+vi.mock("@clack/prompts", () => ({
+	spinner: () => mockSpinner,
+}));
 
 const mockImportLocalOrNpx = vi.fn();
 
@@ -14,31 +24,52 @@ const errorLocal = new Error("Error: local");
 const errorNpx = new Error("Error: npx");
 
 describe("tryImportAndInstallIfNecessary", () => {
-	it("returns the local error when importLocalOrNpx resolves with a failure for a local path", async () => {
+	it("resolves with the local error when importLocalOrNpx resolves with a failure for a local path", async () => {
 		mockImportLocalOrNpx.mockResolvedValueOnce({
 			kind: "failure",
 			local: errorLocal,
 			npx: errorNpx,
 		});
 
-		const actual = await tryImportAndInstallIfNecessary("../create-my-app");
+		const actual = await tryImportAndInstallIfNecessary(
+			"../create-my-app",
+			true,
+		);
 
 		expect(actual).toBe(errorLocal);
+		expect(mockSpinner.start.mock.calls).toEqual([
+			[`Loading ${chalk.blue("../create-my-app")}`],
+		]);
+		expect(mockSpinner.stop.mock.calls).toEqual([
+			[
+				`Could not load ${chalk.blue("../create-my-app")}: ${chalk.red(errorLocal.message)}`,
+				1,
+			],
+		]);
 	});
 
-	it("returns the npx error when importLocalOrNpx resolves with a failure for a package name", async () => {
+	it("resolves with the npx error when importLocalOrNpx resolves with a failure for a package name", async () => {
 		mockImportLocalOrNpx.mockResolvedValueOnce({
 			kind: "failure",
 			local: errorLocal,
 			npx: errorNpx,
 		});
 
-		const actual = await tryImportAndInstallIfNecessary("create-my-app");
+		const actual = await tryImportAndInstallIfNecessary("create-my-app", true);
 
 		expect(actual).toBe(errorNpx);
+		expect(mockSpinner.start.mock.calls).toEqual([
+			[`Loading ${chalk.blue("create-my-app")}`],
+		]);
+		expect(mockSpinner.stop.mock.calls).toEqual([
+			[
+				`Could not load ${chalk.blue("create-my-app")}: ${chalk.red(errorNpx.message)}`,
+				1,
+			],
+		]);
 	});
 
-	it("returns the package when importLocalOrNpx resolves a package", async () => {
+	it("resolves with the package when importLocalOrNpx resolves a package", async () => {
 		const resolved = { happy: true };
 
 		mockImportLocalOrNpx.mockResolvedValueOnce({
@@ -46,8 +77,14 @@ describe("tryImportAndInstallIfNecessary", () => {
 			resolved,
 		});
 
-		const actual = await tryImportAndInstallIfNecessary("create-my-app");
+		const actual = await tryImportAndInstallIfNecessary("create-my-app", true);
 
 		expect(actual).toBe(resolved);
+		expect(mockSpinner.start.mock.calls).toEqual([
+			[`Loading ${chalk.blue("create-my-app")}`],
+		]);
+		expect(mockSpinner.stop.mock.calls).toEqual([
+			[`Loaded ${chalk.blue("create-my-app")}`],
+		]);
 	});
 });

--- a/packages/create/src/cli/importers/tryImportAndInstallIfNecessary.ts
+++ b/packages/create/src/cli/importers/tryImportAndInstallIfNecessary.ts
@@ -1,19 +1,36 @@
+import * as prompts from "@clack/prompts";
+import chalk from "chalk";
 import { importLocalOrNpx } from "import-local-or-npx";
 
 import { isLocalPath } from "../utils.js";
+import { createNpxInstallationConfirm } from "./createNpxInstallationConfirm.js";
 
 export async function tryImportAndInstallIfNecessary(
 	from: string,
+	yes: boolean | undefined,
 ): Promise<Error | object> {
+	const spinner = prompts.spinner();
+
+	spinner.start(`Loading ${chalk.blue(from)}`);
+
 	const imported = await importLocalOrNpx(from, {
+		confirm: createNpxInstallationConfirm(from, spinner, yes),
+
 		// We ignore logs because we don't want to clutter CLI output
 		// eslint-disable-next-line @typescript-eslint/no-empty-function
 		logger: () => {},
 	});
 
 	if (imported.kind === "failure") {
-		return isLocalPath(from) ? imported.local : imported.npx;
+		const template = isLocalPath(from) ? imported.local : imported.npx;
+		spinner.stop(
+			`Could not load ${chalk.blue(from)}: ${chalk.red(template.message)}`,
+			1,
+		);
+		return template;
 	}
+
+	spinner.stop(`Loaded ${chalk.blue(from)}`);
 
 	return imported.resolved;
 }

--- a/packages/create/src/cli/importers/tryImportTemplate.test.ts
+++ b/packages/create/src/cli/importers/tryImportTemplate.test.ts
@@ -1,16 +1,6 @@
-import chalk from "chalk";
 import { describe, expect, it, vi } from "vitest";
 
 import { tryImportTemplate } from "./tryImportTemplate.js";
-
-const mockSpinner = {
-	start: vi.fn(),
-	stop: vi.fn(),
-};
-
-vi.mock("@clack/prompts", () => ({
-	spinner: () => mockSpinner,
-}));
 
 const mockTryImportWithPredicate = vi.fn();
 
@@ -26,18 +16,9 @@ describe("tryImportTemplate", () => {
 
 		mockTryImportWithPredicate.mockResolvedValueOnce(error);
 
-		const actual = await tryImportTemplate("create-my-app");
+		const actual = await tryImportTemplate("create-my-app", false);
 
 		expect(actual).toEqual(error);
-		expect(mockSpinner.start.mock.calls).toEqual([
-			[`Loading ${chalk.blue("create-my-app")}`],
-		]);
-		expect(mockSpinner.stop.mock.calls).toEqual([
-			[
-				`Could not load ${chalk.blue("create-my-app")}: ${chalk.red(error.message)}`,
-				1,
-			],
-		]);
 	});
 
 	it("returns the template when tryImportWithPredicate resolves with a preset", async () => {
@@ -45,14 +26,8 @@ describe("tryImportTemplate", () => {
 
 		mockTryImportWithPredicate.mockResolvedValueOnce(template);
 
-		const actual = await tryImportTemplate("create-my-app");
+		const actual = await tryImportTemplate("create-my-app", false);
 
 		expect(actual).toEqual(template);
-		expect(mockSpinner.start.mock.calls).toEqual([
-			[`Loading ${chalk.blue("create-my-app")}`],
-		]);
-		expect(mockSpinner.stop.mock.calls).toEqual([
-			[`Loaded ${chalk.blue("create-my-app")}`],
-		]);
 	});
 });

--- a/packages/create/src/cli/importers/tryImportTemplate.ts
+++ b/packages/create/src/cli/importers/tryImportTemplate.ts
@@ -1,30 +1,15 @@
-import * as prompts from "@clack/prompts";
-import chalk from "chalk";
-
 import { isTemplate } from "../../predicates/isTemplate.js";
 import { tryImportWithPredicate } from "../tryImportWithPredicate.js";
 import { tryImportAndInstallIfNecessary } from "./tryImportAndInstallIfNecessary.js";
 
-export async function tryImportTemplate(from: string) {
-	const spinner = prompts.spinner();
-	spinner.start(`Loading ${chalk.blue(from)}`);
-
-	const template = await tryImportWithPredicate(
-		tryImportAndInstallIfNecessary,
+export async function tryImportTemplate(
+	from: string,
+	yes: boolean | undefined,
+) {
+	return await tryImportWithPredicate(
+		async () => tryImportAndInstallIfNecessary(from, yes),
 		from,
 		isTemplate,
 		"Template",
 	);
-
-	if (template instanceof Error) {
-		spinner.stop(
-			`Could not load ${chalk.blue(from)}: ${chalk.red(template.message)}`,
-			1,
-		);
-		return template;
-	}
-
-	spinner.stop(`Loaded ${chalk.blue(from)}`);
-
-	return template;
 }

--- a/packages/create/src/cli/importers/tryImportTemplatePreset.test.ts
+++ b/packages/create/src/cli/importers/tryImportTemplatePreset.test.ts
@@ -30,7 +30,11 @@ describe("tryImportTemplatePreset", () => {
 
 		mockTryImportTemplate.mockResolvedValueOnce(error);
 
-		const actual = await tryImportTemplatePreset("create-my-app");
+		const actual = await tryImportTemplatePreset({
+			from: "create-my-app",
+			requestedPreset: undefined,
+			yes: false,
+		});
 
 		expect(actual).toEqual(error);
 		expect(mockPromptForPreset).not.toHaveBeenCalled();
@@ -40,7 +44,11 @@ describe("tryImportTemplatePreset", () => {
 		mockTryImportTemplate.mockResolvedValueOnce({});
 		mockPromptForPreset.mockResolvedValueOnce(mockCancel);
 
-		const actual = await tryImportTemplatePreset("create-my-app");
+		const actual = await tryImportTemplatePreset({
+			from: "create-my-app",
+			requestedPreset: undefined,
+			yes: undefined,
+		});
 
 		expect(actual).toBe(mockCancel);
 	});
@@ -52,7 +60,11 @@ describe("tryImportTemplatePreset", () => {
 		mockTryImportTemplate.mockResolvedValueOnce(template);
 		mockPromptForPreset.mockResolvedValueOnce(preset);
 
-		const actual = await tryImportTemplatePreset("create-my-app");
+		const actual = await tryImportTemplatePreset({
+			from: "create-my-app",
+			requestedPreset: undefined,
+			yes: false,
+		});
 
 		expect(actual).toEqual({ preset, template });
 	});

--- a/packages/create/src/cli/importers/tryImportTemplatePreset.ts
+++ b/packages/create/src/cli/importers/tryImportTemplatePreset.ts
@@ -3,11 +3,18 @@ import * as prompts from "@clack/prompts";
 import { promptForPreset } from "../prompts/promptForPreset.js";
 import { tryImportTemplate } from "./tryImportTemplate.js";
 
-export async function tryImportTemplatePreset(
-	from: string,
-	requestedPreset?: string,
-) {
-	const template = await tryImportTemplate(from);
+export interface TemplatePresetImportSettings {
+	from: string;
+	requestedPreset: string | undefined;
+	yes: boolean | undefined;
+}
+
+export async function tryImportTemplatePreset({
+	from,
+	requestedPreset,
+	yes,
+}: TemplatePresetImportSettings) {
+	const template = await tryImportTemplate(from, yes);
 	if (template instanceof Error) {
 		return template;
 	}

--- a/packages/create/src/cli/initialize/runModeInitialize.test.ts
+++ b/packages/create/src/cli/initialize/runModeInitialize.test.ts
@@ -155,7 +155,24 @@ describe("runModeInitialize", () => {
 
 		expect(mockLogInitializeHelpText).toHaveBeenCalledWith(
 			"create-typescript-app",
-			true,
+			{ help: true, yes: undefined },
+		);
+
+		expect(actual).toBe(mockHelpTextReturn);
+	});
+
+	it("logs help text with yes when from help is true and yes is true", async () => {
+		const actual = await runModeInitialize({
+			args: ["node", "create"],
+			display,
+			from: "create-typescript-app",
+			help: true,
+			yes: true,
+		});
+
+		expect(mockLogInitializeHelpText).toHaveBeenCalledWith(
+			"create-typescript-app",
+			{ help: true, yes: true },
 		);
 
 		expect(actual).toBe(mockHelpTextReturn);

--- a/packages/create/src/cli/initialize/runModeInitialize.ts
+++ b/packages/create/src/cli/initialize/runModeInitialize.ts
@@ -33,6 +33,7 @@ export interface RunModeInitializeSettings {
 	owner?: string;
 	preset?: string;
 	repository?: string;
+	yes?: boolean;
 }
 
 export async function runModeInitialize({
@@ -44,14 +45,15 @@ export async function runModeInitialize({
 	help,
 	offline,
 	preset: requestedPreset,
+	yes,
 }: RunModeInitializeSettings): Promise<ModeResults> {
 	if (!from || help) {
-		return await logInitializeHelpText(from, help);
+		return await logInitializeHelpText(from, { help, yes });
 	}
 
 	logStartText("initialize", from, "template", offline);
 
-	const loaded = await tryImportTemplatePreset(from, requestedPreset);
+	const loaded = await tryImportTemplatePreset({ from, requestedPreset, yes });
 	if (loaded instanceof Error) {
 		return {
 			outro: chalk.red(CLIMessage.Exiting),

--- a/packages/create/src/cli/loggers/logInitializeHelpText.test.ts
+++ b/packages/create/src/cli/loggers/logInitializeHelpText.test.ts
@@ -6,11 +6,12 @@ import { CLIMessage } from "../messages.js";
 import { CLIStatus } from "../status.js";
 import { logInitializeHelpText } from "./logInitializeHelpText.js";
 
+const mockInfo = vi.fn();
 const mockMessage = vi.fn();
 
 vi.mock("@clack/prompts", () => ({
 	get log() {
-		return { message: mockMessage };
+		return { info: mockInfo, message: mockMessage };
 	},
 }));
 
@@ -39,8 +40,11 @@ vi.mock("./logSchemasHelpOptions.js", () => ({
 }));
 
 describe("logInitializeHelpText", () => {
-	it("logs a straightforward message without loading when from is undefined and help is falsy", async () => {
-		const actual = await logInitializeHelpText(undefined, false);
+	it("logs a straightforward message without loading when from is undefined and help is false", async () => {
+		const actual = await logInitializeHelpText(undefined, {
+			help: false,
+			yes: false,
+		});
 
 		expect(actual).toEqual({
 			outro: CLIMessage.Ok,
@@ -56,7 +60,10 @@ describe("logInitializeHelpText", () => {
 	});
 
 	it("logs general help text without loading when from is undefined and help is true", async () => {
-		const actual = await logInitializeHelpText(undefined, true);
+		const actual = await logInitializeHelpText(undefined, {
+			help: true,
+			yes: false,
+		});
 
 		expect(actual).toEqual({
 			outro: CLIMessage.Ok,
@@ -65,13 +72,16 @@ describe("logInitializeHelpText", () => {
 		expect(mockLogHelpText).toHaveBeenCalledWith("initialize");
 	});
 
-	it("returns the error when help is falsy and loading the template is an error", async () => {
+	it("returns the error when help is false and loading the template is an error", async () => {
 		const message = "Oh no!";
 		const from = "create-my-app";
 
 		mockTryImportTemplate.mockResolvedValueOnce(new Error(message));
 
-		const actual = await logInitializeHelpText(from, false);
+		const actual = await logInitializeHelpText(from, {
+			help: false,
+			yes: false,
+		});
 
 		expect(actual).toEqual({
 			outro: chalk.red(CLIMessage.Exiting),
@@ -79,7 +89,7 @@ describe("logInitializeHelpText", () => {
 		});
 	});
 
-	it("returns a success when help is falsy and loading the template succeeds", async () => {
+	it("returns a success when help is false and loading the template succeeds", async () => {
 		const from = "create-my-app";
 		const base = createBase({ options: {} });
 		const template = base.createTemplate({
@@ -88,7 +98,10 @@ describe("logInitializeHelpText", () => {
 
 		mockTryImportTemplate.mockResolvedValueOnce(template);
 
-		const actual = await logInitializeHelpText(from, false);
+		const actual = await logInitializeHelpText(from, {
+			help: false,
+			yes: false,
+		});
 
 		expect(actual).toEqual({
 			outro: CLIMessage.Ok,

--- a/packages/create/src/cli/loggers/logInitializeHelpText.ts
+++ b/packages/create/src/cli/loggers/logInitializeHelpText.ts
@@ -7,9 +7,14 @@ import { CLIStatus } from "../status.js";
 import { logHelpText } from "./logHelpText.js";
 import { logSchemasHelpOptions } from "./logSchemasHelpOptions.js";
 
+export interface InitializeHelpTextOptions {
+	help: boolean | undefined;
+	yes: boolean | undefined;
+}
+
 export async function logInitializeHelpText(
 	from: string | undefined,
-	help: boolean | undefined,
+	{ help, yes }: InitializeHelpTextOptions,
 ) {
 	if (!from) {
 		if (help) {
@@ -34,7 +39,9 @@ export async function logInitializeHelpText(
 		type: "template",
 	});
 
-	const template = await tryImportTemplate(from);
+	prompts.log.info(`Loading ${chalk.blue(from)} to display its options...`);
+
+	const template = await tryImportTemplate(from, yes);
 	if (template instanceof Error) {
 		return {
 			outro: chalk.red(CLIMessage.Exiting),

--- a/packages/create/src/cli/migrate/parseMigrationSource.ts
+++ b/packages/create/src/cli/migrate/parseMigrationSource.ts
@@ -16,6 +16,7 @@ export interface RequestedMigrationSource {
 	directory: string;
 	from?: string;
 	requestedPreset?: string;
+	yes?: boolean;
 }
 
 export function parseMigrationSource({
@@ -23,6 +24,7 @@ export function parseMigrationSource({
 	directory,
 	from,
 	requestedPreset,
+	yes,
 }: RequestedMigrationSource): Error | MigrationSource {
 	if (configFile && from) {
 		return new Error(
@@ -42,7 +44,8 @@ export function parseMigrationSource({
 	if (from) {
 		return {
 			descriptor: from,
-			load: async () => await tryImportTemplatePreset(from, requestedPreset),
+			load: async () =>
+				await tryImportTemplatePreset({ from, requestedPreset, yes }),
 			type: "template",
 		};
 	}

--- a/packages/create/src/cli/migrate/runModeMigrate.ts
+++ b/packages/create/src/cli/migrate/runModeMigrate.ts
@@ -27,6 +27,7 @@ export interface RunModeMigrateSettings {
 	help?: boolean;
 	offline?: boolean;
 	preset?: string | undefined;
+	yes?: boolean;
 }
 
 export async function runModeMigrate({
@@ -38,12 +39,14 @@ export async function runModeMigrate({
 	help,
 	offline,
 	preset: requestedPreset,
+	yes,
 }: RunModeMigrateSettings): Promise<ModeResults> {
 	const source = parseMigrationSource({
 		configFile,
 		directory,
 		from,
 		requestedPreset,
+		yes,
 	});
 
 	if (help) {

--- a/packages/create/src/cli/runCli.ts
+++ b/packages/create/src/cli/runCli.ts
@@ -21,6 +21,7 @@ const valuesSchema = z.object({
 	owner: z.string().optional(),
 	preset: z.string().optional(),
 	repository: z.string().optional(),
+	yes: z.boolean().optional(),
 });
 
 export async function runCli(args: string[]) {
@@ -52,6 +53,9 @@ export async function runCli(args: string[]) {
 				type: "string",
 			},
 			version: {
+				type: "boolean",
+			},
+			yes: {
 				type: "boolean",
 			},
 		},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,8 +132,8 @@ importers:
         specifier: ^8.0.2
         version: 8.0.2
       import-local-or-npx:
-        specifier: ^0.2.0
-        version: 0.2.0
+        specifier: ^0.3.0
+        version: 0.3.0
       octokit:
         specifier: ^4.1.0
         version: 4.1.0
@@ -2597,8 +2597,8 @@ packages:
     resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==}
     engines: {node: '>=6'}
 
-  import-local-or-npx@0.2.0:
-    resolution: {integrity: sha512-K0rFCUuIBX7lmzwp95F4Owg+bRZAUMoiC79fYSRHPG/pi3IFKyMYrc+RE00mC9AWU6J/YZKT8xept5VyLvkvUw==}
+  import-local-or-npx@0.3.0:
+    resolution: {integrity: sha512-H/xGm1bTjVKFZOQUDtACRH0teTzUQMGKrY/W6HMmtLi2tB23eZvfePnxqpPRhN31DvvieFvICNfee7QU87IbjQ==}
     engines: {node: '>=18.3.0'}
 
   import-meta-resolve@4.1.0:
@@ -7079,7 +7079,7 @@ snapshots:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
-  import-local-or-npx@0.2.0:
+  import-local-or-npx@0.3.0:
     dependencies:
       enhanced-resolve: 5.18.0
       npx-import: 1.1.4


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #100
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Uses the new `import-local-or-npx` `confirm` option from https://github.com/JoshuaKGoldberg/import-local-or-npx/pull/16 to ask the user for permission before installing.

```plaintext
┌  ✨ create ✨
│
│  Welcome to create: a delightful repository templating engine.
│  
│  Learn more about create on:
│    https://create.bingo
│
│  Running with mode --initialize using the template:
│    create-example
│
◇  create-example not found locally and --yes not specified. create-example will need to be fetched with npx. 
│
◆  Ok to proceed?
│  ● Yes / ○ No
```

💝 