### PR TITLE
docs: split engine FAQ points into their own FAQ; added comparison table

### DIFF
--- a/packages/site/astro.config.ts
+++ b/packages/site/astro.config.ts
@@ -70,6 +70,7 @@ export default defineConfig({
 								],
 								label: "Packages",
 							},
+							{ label: "Templating FAQs", link: "engine/templating-faqs" },
 						],
 						label: "Templating Engine",
 						link: "/engine/about",

--- a/packages/site/src/content/docs/cli.mdx
+++ b/packages/site/src/content/docs/cli.mdx
@@ -34,9 +34,8 @@ For example, to generate a new repository using [`create-typescript-app`](https:
 │  Learn more about create on:
 │    https://create.bingo
 │
-│  Running with mode --create for a new repository using the template:
+│  Running with mode --initialize for a new repository using the template:
 │    create-typescript-app
-|
 ```
 
 ### Migration Mode
@@ -56,9 +55,8 @@ For example, to update an existing repository to the latest [`create-typescript-
 │  Learn more about create on:
 │    https://create.bingo
 │
-│  Running with mode --create for an existing repository using the template:
+│  Running with mode --migrate for an existing repository using the template:
 │    create-typescript-app
-|
 ```
 
 ## Flags

--- a/packages/site/src/content/docs/engine/concepts/templates.mdx
+++ b/packages/site/src/content/docs/engine/concepts/templates.mdx
@@ -32,7 +32,7 @@ export const templateTypeScriptApp = createTemplate({
 
 A [CLI](../../cli) like `npx create` can then work with that Template to prompt the user for choosing a Preset:
 
-```bash
+```plaintext
 $ npx create typescript-app@beta
 
 ┌  ✨ create ✨
@@ -42,9 +42,8 @@ $ npx create typescript-app@beta
 │  Learn more about create on:
 │    https://create.bingo
 │
-│  Running with mode --create for a new repository using the template:
+│  Running with mode --initialize for a new repository using the template:
 │    create-typescript-app
-|
 ```
 
 :::note

--- a/packages/site/src/content/docs/engine/templating-faqs.mdx
+++ b/packages/site/src/content/docs/engine/templating-faqs.mdx
@@ -1,0 +1,64 @@
+---
+title: Templating FAQs
+---
+
+`create` is _very_ early stage.
+It is just barely past proof-of-concept stage.
+
+Right now, it's being developed as an MVP to generalize the internals of [create-typescript-app](https://github.com/JoshuaKGoldberg/create-typescript-app).
+Soon it will be more stable and these docs will be updated.
+
+## Bases
+
+### Why do Bases use a `produce()` for Options, not Zod methods like `refine` or `transform`?
+
+`create` intentionally does not use any Zod features beyond creating and describing schemas.
+This is for two reasons:
+
+- Bases often need data to be shared between multiple -even many- different Options.
+  Loading implementations become much cleaner when all data loaders can be declared once in a `produce()` function,
+  wrapped in a caching [`lazyValue`](https://github.com/sindresorhus/lazy-value), then used as needed across any number of Options.
+- Long-term, the engine should not be locked into any one schema engine.
+  Adopting Zod-specific features will make it harder to swap between other implementers of [standard-schema](https://github.com/standard-schema/standard-schema) in the future if needed.
+
+See the [`create-typescript-app` Base `produce()` implementation](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/c6714eeb02a5106eb5e4e4694f1e8b590444030d/src/base.ts#L138) for an example of values used across Options.
+
+## Blocks
+
+### This Blocks system is a lot of work. Is there a more straightforward system?
+
+Not yet, but there will be.
+Less-heavyweight engines will soon be available to make authoring straightforward Templates easier.
+See [create#76 🚀 Feature: Switch to a pluggable templating engine system](https://github.com/JoshuaKGoldberg/create/issues/76).
+
+### Why can't we define Addons for Blocks in Presets?
+
+In other words, you might be wondering why the API doesn't allow something like this:
+
+```js
+export const presetExample = base.createPreset({
+	blocks: [
+		myBlock({
+			someArg: "...",
+		}),
+	],
+});
+```
+
+This is because Blocks shouldn't need to be configured.
+Users should be able to turn them off and on at will without any configuration.
+
+Passing Addons to a Block in a Preset means users will have no way to override or remove those Addons.
+
+## Testing
+
+### Why do some testers allow `take` and others the individual system pieces?
+
+It depends on what APIs the entities under test conceptually use.
+
+| Entity                               | Mock    | Why                                                                                           |
+| ------------------------------------ | ------- | --------------------------------------------------------------------------------------------- |
+| [Bases](./engine/concepts/bases)     | `take`  | Bases should go through Inputs to interact with the system.                                   |
+| [Blocks](./engine/concepts/blocks)   | Neither | Blocks should be synchronous and take any input values from their Base Options.               |
+| [Inputs](./engine/runtime/inputs)    | Both    | Inputs receive system pieces, and can also `take` other Inputs.                               |
+| [Presets](./engine/concepts/presets) | System  | High-level users of Presets should not care about low-level implementation details of Inputs. |

--- a/packages/site/src/content/docs/faqs.mdx
+++ b/packages/site/src/content/docs/faqs.mdx
@@ -45,13 +45,187 @@ None target the full feature set of `create`.
 
 In general, `create`'s approach is differentiated from previous projects by:
 
+- Allowing sub-templates that can be swapped individually and add to each other ([Blocks](./concepts/blocks))
+- Built-in support for onboarding existing out-of-template repositories ([migration mode](./cli/#migration-mode))
 - Producing outputs -including files and more- in a generalized format ([Direct Creations](./runtime/creations#direct-creations))
-- Allowing sub-templates that can be individually swapped individually and add to each other ([Blocks](./concepts/blocks))
+
+### Comparisons Table
 
 :::danger
 Most of these project comparisons have not yet been vetted by maintainers on the projects.
 They might be wildly inaccurate.
 :::
+
+<table class="comparison">
+	<thead>
+		<tr>
+			<th align="middle" rowspan="2">
+				Tool
+			</th>
+			<th rowspan="2">Ecosystem</th>
+			<th rowspan="2">Project Coupling</th>
+			<th colspan="2">File Descriptions</th>
+			<th colspan="3">Scale</th>
+		</tr>
+		<tr>
+			<td>In-Memory</td>
+			<td>Template Files</td>
+			<td>Initializing Repositories</td>
+			<td>Managed Migrations</td>
+			<td>Reusable Components</td>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th>
+				<code>create</code>
+			</th>
+			<td>Web</td>
+			<td>Decoupled</td>
+			<td>
+				<a
+					href="https://github.com/JoshuaKGoldberg/create/issues/76"
+					target="_blank"
+					title="create/issues/76"
+				>
+					#76
+				</a>
+			</td>
+			<td>✅</td>
+			<td>✅</td>
+			<td>✅</td>
+			<td>
+				<a
+					href="https://github.com/JoshuaKGoldberg/create/issues/39"
+					target="_blank"
+					title="create/issues/39"
+				>
+					#39
+				</a>
+			</td>
+		</tr>
+		<tr>
+			<th>
+				<a href="#cookiecutter">Cookiecutter</a>
+			</th>
+			<td>Python</td>
+			<td>Decoupled</td>
+			<td></td>
+			<td>✅</td>
+			<td>✅</td>
+			<td>
+				<a
+					href="https://github.com/cookiecutter/cookiecutter/issues/1004"
+					target="_blank"
+					title="cookiecutter/issues/1004"
+				>
+					#1004
+				</a>
+			</td>
+			<td>
+				<a
+					href="https://github.com/cookiecutter/cookiecutter/issues/1172"
+					target="_blank"
+					title="cookiecutter/issues/1172"
+				>
+					#1172
+				</a>
+			</td>
+		</tr>
+		<tr>
+			<th>
+				<a href="#copier">copier</a>
+			</th>
+			<td>Python</td>
+			<td>Decoupled</td>
+			<td></td>
+			<td>✅</td>
+			<td>✅</td>
+			<td>✅</td>
+			<td></td>
+		</tr>
+		<tr>
+			<th>
+				<a href="#degit">degit</a>
+			</th>
+			<td>Web</td>
+			<td>Decoupled</td>
+			<td></td>
+			<td>✅</td>
+			<td>✅</td>
+			<td></td>
+			<td></td>
+		</tr>
+		<tr>
+			<th>
+				<a href="#github-template-repositories">GitHub Template Repositories</a>
+			</th>
+			<td>(all)</td>
+			<td>Decoupled</td>
+			<td></td>
+			<td>✅</td>
+			<td>✅</td>
+			<td></td>
+			<td></td>
+		</tr>
+		<tr>
+			<th>
+				<a href="#hygen">Hygen</a>
+			</th>
+			<td>Web</td>
+			<td>Decoupled</td>
+			<td></td>
+			<td>✅</td>
+			<td>✅</td>
+			<td></td>
+			<td>✅</td>
+		</tr>
+		<tr>
+			<th>
+				<a href="#plop">Plop</a>
+			</th>
+			<td>Web</td>
+			<td>Config File</td>
+			<td></td>
+			<td>✅</td>
+			<td>✅</td>
+			<td></td>
+			<td>✅</td>
+		</tr>
+		<tr>
+			<th>
+				<a href="#projen">projen</a>
+			</th>
+			<td>Web</td>
+			<td>Coupled</td>
+			<td>✅</td>
+			<td>✅</td>
+			<td>✅</td>
+			<td></td>
+			<td>✅</td>
+		</tr>
+		<tr>
+			<th>
+				<a href="#yeoman">Yeoman</a>
+			</th>
+			<td>Web</td>
+			<td>Decoupled</td>
+			<td>✅</td>
+			<td>✅</td>
+			<td>✅</td>
+			<td>
+				<a
+					href="https://github.com/yeoman/yo/issues/474"
+					target="_blank"
+					title="yo/issues/474"
+				>
+					#474
+				</a>
+			</td>
+			<td>✅</td>
+		</tr>
+	</tbody>
+</table>
 
 ### `create-next-app`, `create-react-app`, `create-typescript-app`, etc
 
@@ -73,7 +247,7 @@ It allows taking in directories written as [Jinja](https://palletsprojects.com/p
 
 - Cookiecutter is a wrapper around a Jinja file templates; `create` allows for full JavaScript logic to generate contents based on provided options
 - Cookiecutter always operates at the scale of one template; `create` provides more granular APIs for areas of features (Blocks and Presets)
-- Cookiecutter supports file changes; `create` additionally supports network calls and arbitrary shell scripts as outputs
+- Cookiecutter supports file changes and execution hooks; `create` additionally supports network calls and arbitrary shell scripts as outputs
 
 Cookiecutter is also written in Python and is installed using tools in the Python ecosystem.
 `create` is written in TypeScript and is set up to work in the web ecosystem.
@@ -116,7 +290,7 @@ Created repositories appear on github.com with a _generated from ..._ notice.
 
 ### Hygen
 
-[Hygen](https://hygen.io) is web ecosystem tool for defining generators to automate common file system tasks.
+[Hygen](https://github.com/jondot/hygen) is a web ecosystem tool for defining generators to automate common file system tasks.
 It encourages building your own generators that include templates built with the [EJS](https://ejs.co) embedded JavaScript templating engine.
 Hygen templates can have conditional rendering, embedded JavaScript, and injected shell scripts.
 
@@ -125,6 +299,7 @@ Hygen templates can have conditional rendering, embedded JavaScript, and injecte
 - Hygen templates are imperative descriptions of files and frontmatter; `create` groups areas into blocks
 - Hygen templates heavily build on EJS and do not have type-safe options; `create` has options explicitly defined with Zod schemas
 - `create` Blocks describe their own outputs and additions to other Blocks, allowing them to be individually toggled
+- Hygen prioritizes granular individual templates; `create` priotizes full repository templates
 
 ### Plop
 
@@ -186,38 +361,6 @@ Yeoman has not been actively maintained in several years.
 
 ## Template Development
 
-### This Blocks system is a lot of work. Is there a more straightforward system?
+[Templating Engine](../engine/about) covers how to develop templates for `create`.
 
-Not yet, but there will be.
-Soon, less-heavyweight engines will be available to make authoring straightforward Templates easier.
-See [create#76 🚀 Feature: Switch to a pluggable templating engine system](https://github.com/JoshuaKGoldberg/create/issues/76).
-
-### Why can't we define Args for Blocks in Presets?
-
-In other words, you might be wondering why the API doesn't allow something like this:
-
-```js
-export const presetExample = base.createPreset({
-	blocks: [
-		myBlock({
-			someArg: "...",
-		}),
-	],
-});
-```
-
-This is because Blocks shouldn't need to be configured.
-Users should be able to turn them off and on at will without any configuration.
-
-Passing Args to a Block in a Preset means users will have no way to override or remove those Args.
-
-### Why do some testers allow `take` and others the individual system pieces?
-
-It depends on what APIs the entities under test conceptually use.
-
-| Entity                               | Mock    | Why                                                                                           |
-| ------------------------------------ | ------- | --------------------------------------------------------------------------------------------- |
-| [Bases](./engine/concepts/bases)     | `take`  | Bases should go through Inputs to interact with the system.                                   |
-| [Blocks](./engine/concepts/blocks)   | Neither | Blocks should be synchronous and take any input values from their Base Options.               |
-| [Inputs](./engine/runtime/inputs)    | Both    | Inputs receive system pieces, and can also `take` other Inputs.                               |
-| [Presets](./engine/concepts/presets) | System  | High-level users of Presets should not care about low-level implementation details of Inputs. |
+See [Templating Engine > FAQs](../engine/faqs) for FAQs on template development.

--- a/packages/site/src/styles.css
+++ b/packages/site/src/styles.css
@@ -94,3 +94,37 @@ a.secondary {
 	border-radius: 3px;
 	font-weight: bold;
 }
+
+.sl-markdown-content table.comparison {
+	font-size: 70%;
+}
+
+.sl-markdown-content table.comparison thead td {
+	text-align: center;
+}
+
+.sl-markdown-content table.comparison td {
+	padding-inline: 0.25rem;
+	text-align: center;
+	vertical-align: middle;
+}
+
+.sl-markdown-content table.comparison thead th:first-of-type {
+	font-size: var(--sl-text-base);
+	padding: 0;
+	text-align: left;
+}
+
+.sl-markdown-content table.comparison thead th:not(:first-of-type) {
+	text-align: center;
+}
+
+.sl-markdown-content table.comparison thead th {
+	vertical-align: middle;
+	padding: 0.25rem 0.5rem;
+}
+
+.sl-markdown-content table.comparison tbody tr th {
+	font-size: var(--sl-text-sm);
+	padding-inline: 0;
+}

--- a/packages/site/tsconfig.build.json
+++ b/packages/site/tsconfig.build.json
@@ -6,5 +6,6 @@
 		},
 		"target": "esnext"
 	},
-	"extends": "astro/tsconfigs/strict"
+	"extends": "astro/tsconfigs/strict",
+	"exclude": ["astro.config.ts"]
 }


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #112; fixes #152
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Lumps these two areas of docs work together because I was in the area and thinking about engine docs holistically.

💖 