### PR TITLE
docs: switch from 'very early stage' to 'early stage'

### DIFF
--- a/packages/create/README.md
+++ b/packages/create/README.md
@@ -25,11 +25,10 @@ It's like a modern version of [Yeoman](https://yeoman.io), but:
 
 ## Status
 
-`create` is _very_ early stage.
-It is just barely past proof-of-concept stage.
-
-At the moment, it's being developed as an MVP to replace the internals of [create-typescript-app](https://github.com/JoshuaKGoldberg/create-typescript-app).
-See [FAQs > How do I use `create`?](./faqs#how-do-i-use-create).
+`create` is early stage.
+It runs well but its APIs are still in flux.
+Please try it out and report any issues on GitHub!
+🙏
 
 > 💙 This package was templated with [`create-typescript-app`](https://github.com/JoshuaKGoldberg/create-typescript-app).
 

--- a/packages/site/src/content/docs/about.mdx
+++ b/packages/site/src/content/docs/about.mdx
@@ -34,8 +34,3 @@ Existing template options are inferred from your existing repository.
 Rich persistent customizations can be defined in a configuration file.
 
 Put together, `create` is a comprehensive solution for keeping repositories on the latest and greatest in web development tooling.
-
-## Status
-
-`create` is _very_ early stage.
-See [FAQs](./faqs) for more information.

--- a/packages/site/src/content/docs/engine/templating-faqs.mdx
+++ b/packages/site/src/content/docs/engine/templating-faqs.mdx
@@ -2,12 +2,6 @@
 title: Templating FAQs
 ---
 
-`create` is _very_ early stage.
-It is just barely past proof-of-concept stage.
-
-Right now, it's being developed as an MVP to generalize the internals of [create-typescript-app](https://github.com/JoshuaKGoldberg/create-typescript-app).
-Soon it will be more stable and these docs will be updated.
-
 ## Bases
 
 ### Why do Bases use a `produce()` for Options, not Zod methods like `refine` or `transform`?

--- a/packages/site/src/content/docs/faqs.mdx
+++ b/packages/site/src/content/docs/faqs.mdx
@@ -2,11 +2,10 @@
 title: FAQs
 ---
 
-`create` is _very_ early stage.
-It is just barely past proof-of-concept stage.
-
-Right now, it's being developed as an MVP to generalize the internals of [create-typescript-app](https://github.com/JoshuaKGoldberg/create-typescript-app).
-Soon it will be more stable and these docs will be updated.
+`create` is early stage.
+It runs well but its APIs are still in flux.
+Please try it out and report any issues on GitHub!
+🙏
 
 ## Consumption
 

--- a/packages/site/src/content/docs/index.mdx
+++ b/packages/site/src/content/docs/index.mdx
@@ -1,6 +1,6 @@
 ---
 banner:
-  content: create is very early stage. Expect greatness, but don't be surprised by breakages. Please report any issues on GitHub! 🙏
+  content: create is early stage. It runs well but its APIs are still in flux. Please try it out and report any issues on GitHub! 🙏
 description: create is a repository templating engine that allows you to instantiate ready-to-use repositories from flexible, powerful templates.
 template: splash
 hero:


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #141
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [ ] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This docs issue effectively closes [milestones/2 Blocks Launch](https://github.com/JoshuaKGoldberg/create/milestone/2) by promoting how the docs phrase this project's status. Instead of _"**very** early stage"_, it's now ... just _"early stage"_. Very exciting.

💝 