### PR TITLE
fix: allow explicit `--from` again

### DIFF
--- a/packages/create/src/cli/findPositionalFrom.ts
+++ b/packages/create/src/cli/findPositionalFrom.ts
@@ -1,7 +1,6 @@
 import { isLocalPath } from "./utils.js";
 
 export function findPositionalFrom(positionals: string[]) {
-	console.log({ positionals });
 	const from = positionals.find((positional) => !positional.startsWith("-"));
 
 	return from && !isLocalPath(from) && !from.startsWith("create-")

--- a/packages/create/src/cli/findPositionalFrom.ts
+++ b/packages/create/src/cli/findPositionalFrom.ts
@@ -1,6 +1,7 @@
 import { isLocalPath } from "./utils.js";
 
 export function findPositionalFrom(positionals: string[]) {
+	console.log({ positionals });
 	const from = positionals.find((positional) => !positional.startsWith("-"));
 
 	return from && !isLocalPath(from) && !from.startsWith("create-")

--- a/packages/create/src/cli/runCli.test.ts
+++ b/packages/create/src/cli/runCli.test.ts
@@ -99,7 +99,43 @@ describe("readProductionSettings", () => {
 		expect(mockLogOutro).toHaveBeenCalledWith(chalk.red(message));
 	});
 
-	it("runs initialize mode when readProductionSettings resolves with mode: initialize", async () => {
+	it("runs initialize mode when readProductionSettings resolves with mode: initialize and no --from is specified", async () => {
+		const args: string[] = [];
+		const status = CLIStatus.Success;
+
+		mockReadProductionSettings.mockResolvedValueOnce({ mode: "initialize" });
+		mockRunModeInitialize.mockResolvedValueOnce({ status });
+
+		const actual = await runCli(args);
+
+		expect(actual).toEqual(status);
+		expect(mockRunModeInitialize).toHaveBeenCalledWith({
+			args,
+			display: mockDisplay,
+			from: undefined,
+		});
+		expect(mockRunModeMigrate).not.toHaveBeenCalled();
+	});
+
+	it("runs initialize mode when readProductionSettings resolves with mode: initialize and an explicit --from is specified", async () => {
+		const args = ["--from", "../create-typescript-app"];
+		const status = CLIStatus.Success;
+
+		mockReadProductionSettings.mockResolvedValueOnce({ mode: "initialize" });
+		mockRunModeInitialize.mockResolvedValueOnce({ status });
+
+		const actual = await runCli(args);
+
+		expect(actual).toEqual(status);
+		expect(mockRunModeInitialize).toHaveBeenCalledWith({
+			args,
+			display: mockDisplay,
+			from: "../create-typescript-app",
+		});
+		expect(mockRunModeMigrate).not.toHaveBeenCalled();
+	});
+
+	it("runs initialize mode when readProductionSettings resolves with mode: initialize and an implicit --from is specified", async () => {
 		const args = ["typescript-app"];
 		const status = CLIStatus.Success;
 

--- a/packages/create/src/cli/runCli.ts
+++ b/packages/create/src/cli/runCli.ts
@@ -96,7 +96,7 @@ export async function runCli(args: string[]) {
 		...validatedValues,
 		args,
 		display,
-		from: findPositionalFrom(positionals),
+		from: validatedValues.from ?? findPositionalFrom(positionals),
 	};
 
 	const { outro, status, suggestions } =


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #161
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Uses the parsed `from` from parsing args, if it exists. Previously that value was being ignored.

I filled in some extra unit test coverage to make sure initialization mode (`runModeInitialize`) is called for all of the three known `from` cases:

* None: `npx create` to just show the brief intro/welcome text
* Explicit: `npx create --from ../create-my-template`
* Implicit: `npx create my-template`

💝 