### PR TITLE
fix: always surface CLI errors

### DIFF
--- a/packages/bingo/src/cli/importers/tryImportAndInstallIfNecessary.test.ts
+++ b/packages/bingo/src/cli/importers/tryImportAndInstallIfNecessary.test.ts
@@ -41,10 +41,7 @@ describe("tryImportAndInstallIfNecessary", () => {
 			[`Loading ${chalk.blue("../create-my-app")}`],
 		]);
 		expect(mockSpinner.stop.mock.calls).toEqual([
-			[
-				`Could not load ${chalk.blue("../create-my-app")}: ${chalk.red(errorLocal.message)}`,
-				1,
-			],
+			[`Could not load ${chalk.blue("../create-my-app")}.`, 1],
 		]);
 	});
 
@@ -62,10 +59,7 @@ describe("tryImportAndInstallIfNecessary", () => {
 			[`Loading ${chalk.blue("bingo-my-app")}`],
 		]);
 		expect(mockSpinner.stop.mock.calls).toEqual([
-			[
-				`Could not load ${chalk.blue("bingo-my-app")}: ${chalk.red(errorNpx.message)}`,
-				1,
-			],
+			[`Could not load ${chalk.blue("bingo-my-app")}.`, 1],
 		]);
 	});
 

--- a/packages/bingo/src/cli/importers/tryImportAndInstallIfNecessary.ts
+++ b/packages/bingo/src/cli/importers/tryImportAndInstallIfNecessary.ts
@@ -23,10 +23,7 @@ export async function tryImportAndInstallIfNecessary(
 
 	if (imported.kind === "failure") {
 		const template = isLocalPath(from) ? imported.local : imported.npx;
-		spinner.stop(
-			`Could not load ${chalk.blue(from)}: ${chalk.red(template.message)}`,
-			1,
-		);
+		spinner.stop(`Could not load ${chalk.blue(from)}.`, 1);
 		return template;
 	}
 

--- a/packages/bingo/src/cli/loggers/logSetupHelpText.test.ts
+++ b/packages/bingo/src/cli/loggers/logSetupHelpText.test.ts
@@ -73,10 +73,10 @@ describe("logSetupHelpText", () => {
 	});
 
 	it("returns the error when help is false and loading the template is an error", async () => {
-		const message = "Oh no!";
 		const from = "bingo-my-app";
+		const error = new Error("Oh no!");
 
-		mockTryImportTemplate.mockResolvedValueOnce(new Error(message));
+		mockTryImportTemplate.mockResolvedValueOnce(error);
 
 		const actual = await logSetupHelpText(from, {
 			help: false,
@@ -84,7 +84,8 @@ describe("logSetupHelpText", () => {
 		});
 
 		expect(actual).toEqual({
-			outro: chalk.red(CLIMessage.Exiting),
+			error,
+			outro: CLIMessage.Exiting,
 			status: CLIStatus.Error,
 		});
 	});

--- a/packages/bingo/src/cli/loggers/logSetupHelpText.ts
+++ b/packages/bingo/src/cli/loggers/logSetupHelpText.ts
@@ -4,6 +4,7 @@ import chalk from "chalk";
 import { tryImportTemplate } from "../importers/tryImportTemplate.js";
 import { CLIMessage } from "../messages.js";
 import { CLIStatus } from "../status.js";
+import { ModeResults } from "../types.js";
 import { logHelpText } from "./logHelpText.js";
 import { logSchemasHelpOptions } from "./logSchemasHelpOptions.js";
 
@@ -15,7 +16,7 @@ export interface SetupHelpTextOptions {
 export async function logSetupHelpText(
 	from: string | undefined,
 	{ help, yes }: SetupHelpTextOptions,
-) {
+): Promise<ModeResults> {
 	if (!from) {
 		if (help) {
 			logHelpText("setup");
@@ -44,7 +45,8 @@ export async function logSetupHelpText(
 	const template = await tryImportTemplate(from, yes);
 	if (template instanceof Error) {
 		return {
-			outro: chalk.red(CLIMessage.Exiting),
+			error: template,
+			outro: CLIMessage.Exiting,
 			status: CLIStatus.Error,
 		};
 	}

--- a/packages/bingo/src/cli/loggers/logTransitionHelpText.test.ts
+++ b/packages/bingo/src/cli/loggers/logTransitionHelpText.test.ts
@@ -33,6 +33,7 @@ describe("logTransitionHelpText", () => {
 		const actual = await logTransitionHelpText(source);
 
 		expect(actual).toEqual({
+			error: source,
 			outro: CLIMessage.Exiting,
 			status: CLIStatus.Error,
 		});
@@ -41,22 +42,23 @@ describe("logTransitionHelpText", () => {
 
 	it("returns the error when source.load resolves with an error", async () => {
 		const descriptor = "bingo-test-app";
-		const message = "Oh no!";
+		const error = new Error("Oh no!");
 		const source: TransitionSource = {
 			descriptor,
-			load: () => Promise.resolve(new Error(message)),
+			load: () => Promise.resolve(error),
 			type: "template",
 		};
 
 		const actual = await logTransitionHelpText(source);
 
 		expect(actual).toEqual({
+			error,
 			outro: CLIMessage.Exiting,
 			status: CLIStatus.Error,
 		});
 		expect(mockLogHelpText).toHaveBeenCalledWith("transition", source);
 		expect(mockSpinner.stop).toHaveBeenCalledWith(
-			`Could not load ${chalk.blue(descriptor)}: ${chalk.red(message)}`,
+			`Could not load ${chalk.blue(descriptor)}.`,
 			1,
 		);
 	});

--- a/packages/bingo/src/cli/loggers/logTransitionHelpText.ts
+++ b/packages/bingo/src/cli/loggers/logTransitionHelpText.ts
@@ -4,13 +4,20 @@ import chalk from "chalk";
 import { CLIMessage } from "../messages.js";
 import { CLIStatus } from "../status.js";
 import { TransitionSource } from "../transition/parseTransitionSource.js";
+import { ModeResults } from "../types.js";
 import { logHelpText } from "./logHelpText.js";
 
-export async function logTransitionHelpText(source: Error | TransitionSource) {
+export async function logTransitionHelpText(
+	source: Error | TransitionSource,
+): Promise<ModeResults> {
 	logHelpText("transition", source);
 
 	if (source instanceof Error) {
-		return { outro: CLIMessage.Exiting, status: CLIStatus.Error };
+		return {
+			error: source,
+			outro: CLIMessage.Exiting,
+			status: CLIStatus.Error,
+		};
 	}
 
 	const spinner = prompts.spinner();
@@ -19,11 +26,12 @@ export async function logTransitionHelpText(source: Error | TransitionSource) {
 	const loaded = await source.load();
 
 	if (loaded instanceof Error) {
-		spinner.stop(
-			`Could not load ${chalk.blue(source.descriptor)}: ${chalk.red(loaded.message)}`,
-			1,
-		);
-		return { outro: CLIMessage.Exiting, status: CLIStatus.Error };
+		spinner.stop(`Could not load ${chalk.blue(source.descriptor)}.`, 1);
+		return {
+			error: loaded,
+			outro: CLIMessage.Exiting,
+			status: CLIStatus.Error,
+		};
 	}
 
 	if (prompts.isCancel(loaded)) {

--- a/packages/bingo/src/cli/runCli.ts
+++ b/packages/bingo/src/cli/runCli.ts
@@ -7,6 +7,7 @@ import { packageData } from "../packageData.js";
 import { createClackDisplay } from "./display/createClackDisplay.js";
 import { findPositionalFrom } from "./findPositionalFrom.js";
 import { logOutro } from "./loggers/logOutro.js";
+import { CLIMessage } from "./messages.js";
 import { readProductionSettings } from "./readProductionSettings.js";
 import { runModeSetup } from "./setup/runModeSetup.js";
 import { CLIStatus } from "./status.js";
@@ -95,7 +96,7 @@ export async function runCli(args: string[]) {
 		from: validatedValues.from ?? findPositionalFrom(positionals),
 	};
 
-	const { outro, status, suggestions } =
+	const results =
 		productionSettings.mode === "setup"
 			? await runModeSetup(sharedSettings)
 			: await runModeTransition({
@@ -103,11 +104,14 @@ export async function runCli(args: string[]) {
 					configFile: productionSettings.configFile,
 				});
 
+	if (results.status === CLIStatus.Error) {
+		prompts.log.error(chalk.red(`Error: ${results.error.message}`));
+	}
+
 	logOutro(
-		outro ??
-			chalk.yellow("Operation cancelled. Exiting - maybe another time? 👋"),
-		{ items: display.dumpItems(), suggestions },
+		results.outro ?? chalk.yellow(`Operation cancelled. ${CLIMessage.Exiting}`),
+		{ items: display.dumpItems(), suggestions: results.suggestions },
 	);
 
-	return status;
+	return results.status;
 }

--- a/packages/bingo/src/cli/setup/runModeSetup.ts
+++ b/packages/bingo/src/cli/setup/runModeSetup.ts
@@ -53,7 +53,8 @@ export async function runModeSetup({
 	const template = await tryImportTemplate(from, yes);
 	if (template instanceof Error) {
 		return {
-			outro: chalk.red(CLIMessage.Exiting),
+			error: template,
+			outro: CLIMessage.Exiting,
 			status: CLIStatus.Error,
 		};
 	}
@@ -124,6 +125,7 @@ export async function runModeSetup({
 	if (creation instanceof Error) {
 		logRerunSuggestion(args, baseOptions.prompted);
 		return {
+			error: creation,
 			outro: `Leaving changes to the local directory on disk. 👋`,
 			status: CLIStatus.Error,
 		};

--- a/packages/bingo/src/cli/transition/runModeTransition.test.ts
+++ b/packages/bingo/src/cli/transition/runModeTransition.test.ts
@@ -181,6 +181,7 @@ describe("runModeTransition", () => {
 		});
 
 		expect(actual).toEqual({
+			error,
 			outro: error.message,
 			status: CLIStatus.Error,
 		});
@@ -200,6 +201,7 @@ describe("runModeTransition", () => {
 		});
 
 		expect(actual).toEqual({
+			error,
 			outro: error.message,
 			status: CLIStatus.Error,
 		});
@@ -241,11 +243,13 @@ describe("runModeTransition", () => {
 	});
 
 	it("returns the error when runTemplate resolves with an error", async () => {
+		const error = new Error("Oh no!");
+
 		mockParseTransitionSource.mockReturnValueOnce(source);
 		mockPromptForOptions.mockResolvedValueOnce({
 			prompted: promptedOptions,
 		});
-		mockRunTemplate.mockRejectedValueOnce(new Error("Oh no!"));
+		mockRunTemplate.mockRejectedValueOnce(error);
 
 		const actual = await runModeTransition({
 			args,
@@ -254,6 +258,7 @@ describe("runModeTransition", () => {
 		});
 
 		expect(actual).toEqual({
+			error,
 			outro: `Leaving changes to the local directory on disk. 👋`,
 			status: CLIStatus.Error,
 		});

--- a/packages/bingo/src/cli/transition/runModeTransition.ts
+++ b/packages/bingo/src/cli/transition/runModeTransition.ts
@@ -51,6 +51,7 @@ export async function runModeTransition({
 
 	if (source instanceof Error) {
 		return {
+			error: source,
 			outro: source.message,
 			status: CLIStatus.Error,
 		};
@@ -61,6 +62,7 @@ export async function runModeTransition({
 	const template = await source.load();
 	if (template instanceof Error) {
 		return {
+			error: template,
 			outro: template.message,
 			status: CLIStatus.Error,
 		};
@@ -120,6 +122,7 @@ export async function runModeTransition({
 	if (creation instanceof Error) {
 		logRerunSuggestion(args, baseOptions.prompted);
 		return {
+			error: creation,
 			outro: `Leaving changes to the local directory on disk. 👋`,
 			status: CLIStatus.Error,
 		};

--- a/packages/bingo/src/cli/types.ts
+++ b/packages/bingo/src/cli/types.ts
@@ -1,7 +1,19 @@
-export interface ModeResults {
+import { CLIStatus } from "./status.js";
+
+export type ModeResults = ModeResultsError | ModeResultsNonError;
+
+export interface ModeResultsBase {
 	outro?: string;
-	status: number;
 	suggestions?: string[];
+}
+
+export interface ModeResultsError extends ModeResultsBase {
+	error: Error;
+	status: CLIStatus.Error;
+}
+
+export interface ModeResultsNonError extends ModeResultsBase {
+	status: CLIStatus.Cancelled | CLIStatus.Success;
 }
 
 export type ProductionSettings =


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #207
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/bingo/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/bingo/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Switches individual error logging to always happen in `runCli`.

```plaintext
┌  ✨ Welcome to Bingo: a delightful repository templating engine. ✨
│
│  Learn more about Bingo on:
│    https://create.bingo
│
│  Running with mode --setup using the template:
│    create-typescript-app@beta
│
◇  create-typescript-app@beta not found locally and --yes specified. create-typescript-app@beta will be fetched with npx. 
│
◇  Loaded create-typescript-app@beta
│
■  Error: The default export of create-typescript-app@beta should be a Template.
│
└  Exiting - maybe another time? 👋
```

I don't love that the error stacks still aren't logged. But there's no concept of "verbose" logging yet in the system. That can be added later.

💝 