### PR TITLE
fix: forward execution mode to Stratum templates

### DIFF
--- a/packages/bingo-testers/src/testTemplate.test.ts
+++ b/packages/bingo-testers/src/testTemplate.test.ts
@@ -19,8 +19,8 @@ describe("testTemplate", () => {
 			},
 		});
 
-		it("passes options to the block when provided via options", async () => {
-			const actual = await testTemplate(template, {
+		it("passes options to the block when provided via options", () => {
+			const actual = testTemplate(template, {
 				options: { value: "abc" },
 			});
 

--- a/packages/bingo-testers/src/testTemplate.ts
+++ b/packages/bingo-testers/src/testTemplate.ts
@@ -17,11 +17,11 @@ export interface TestTemplateProductionSettings<OptionsShape extends AnyShape>
 	options: InferredObject<OptionsShape>;
 }
 
-export async function testTemplate<OptionsShape extends AnyShape>(
+export function testTemplate<OptionsShape extends AnyShape>(
 	template: Template<OptionsShape>,
 	settings: TestTemplateProductionSettings<OptionsShape>,
 ) {
 	const { system } = createMockSystems(settings.system);
 
-	return await produceTemplate(template, { ...settings, ...system });
+	return produceTemplate(template, { ...settings, ...system });
 }

--- a/packages/bingo/src/producers/produceTemplate.test.ts
+++ b/packages/bingo/src/producers/produceTemplate.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { createTemplate } from "../creators/createTemplate.js";
+import { produceTemplate } from "./produceTemplate.js";
+
+const template = createTemplate({
+	about: { name: "Test Template" },
+	options: {
+		title: z.string(),
+	},
+	produce({ options }) {
+		return {
+			files: {
+				"README.md": `# ${options.title}`,
+			},
+		};
+	},
+	setup({ options }) {
+		return {
+			files: {
+				"README-setup.md": `# ${options.title}`,
+			},
+		};
+	},
+	transition({ options }) {
+		return {
+			files: {
+				"README-transition.md": `# ${options.title}`,
+			},
+		};
+	},
+});
+
+describe("produceTemplate", () => {
+	it("runs the template's produce without augmentations when mode is undefined", () => {
+		const creation = produceTemplate(template, {
+			options: { title: "Test Title" },
+		});
+
+		expect(creation).toEqual({
+			files: {
+				"README.md": `# Test Title`,
+			},
+		});
+	});
+
+	it("runs the template's produce and setup when mode is setup", () => {
+		const creation = produceTemplate(template, {
+			mode: "setup",
+			options: { title: "Test Title" },
+		});
+
+		expect(creation).toEqual({
+			files: {
+				"README-setup.md": `# Test Title`,
+				"README.md": `# Test Title`,
+			},
+		});
+	});
+
+	it("runs the template's produce and transition when mode is transition", () => {
+		const creation = produceTemplate(template, {
+			mode: "transition",
+			options: { title: "Test Title" },
+		});
+
+		expect(creation).toEqual({
+			files: {
+				"README-transition.md": `# Test Title`,
+				"README.md": `# Test Title`,
+			},
+		});
+	});
+});

--- a/packages/bingo/src/producers/produceTemplate.ts
+++ b/packages/bingo/src/producers/produceTemplate.ts
@@ -1,6 +1,6 @@
 import { BingoSystem } from "bingo-systems";
 
-import { createSystemContextWithAuth } from "../contexts/createSystemContextWithAuth.js";
+import { createSystemContext } from "../contexts/createSystemContext.js";
 import { mergeCreations } from "../mergers/mergeCreations.js";
 import { AnyShape, InferredObject } from "../options.js";
 import { Creation } from "../types/creations.js";
@@ -14,20 +14,16 @@ export interface ProduceTemplateSettings<OptionsShape extends AnyShape>
 	options: InferredObject<OptionsShape>;
 }
 
-export async function produceTemplate<OptionsShape extends AnyShape>(
+export function produceTemplate<OptionsShape extends AnyShape>(
 	template: Template<OptionsShape>,
 	settings: ProduceTemplateSettings<OptionsShape>,
-): Promise<Partial<Creation>> {
-	const system = await createSystemContextWithAuth({
+): Partial<Creation> {
+	const system = createSystemContext({
 		directory: ".",
 		...settings,
 	});
 
-	const context = {
-		...system,
-		options: settings.options,
-	};
-
+	const context = { ...settings, ...system };
 	let creation = template.produce(context);
 
 	const augmenter = settings.mode && template[settings.mode];

--- a/packages/bingo/src/runners/runTemplate.ts
+++ b/packages/bingo/src/runners/runTemplate.ts
@@ -34,7 +34,7 @@ export async function runTemplate<OptionsShape extends AnyShape>(
 		...settings,
 	});
 
-	const creation = await produceTemplate(template, { ...system, ...settings });
+	const creation = produceTemplate(template, { ...system, ...settings });
 
 	await runCreation(creation, { offline, system });
 

--- a/packages/site/src/content/docs/build/packages/bingo-testers.mdx
+++ b/packages/site/src/content/docs/build/packages/bingo-testers.mdx
@@ -414,8 +414,8 @@ import { describe, expect, it } from "vitest";
 import { exampleTemplate } from "./exampleTemplate.js";
 
 describe("exampleTemplate", () => {
-	it("creates an .nvmrc file", async () => {
-		const actual = await testTemplate(exampleTemplate);
+	it("creates an .nvmrc file", () => {
+		const actual = testTemplate(exampleTemplate);
 
 		expect(actual).toEqual({
 			files: { ".nvmrc": "20.12.2" },
@@ -445,8 +445,8 @@ import { describe, expect, it } from "vitest";
 import { exampleTemplate } from "./exampleTemplate.js";
 
 describe("exampleTemplate", () => {
-	it("returns an .nvmrc", async () => {
-		const actual = await testTemplate(exampleTemplate, {
+	it("returns an .nvmrc", () => {
+		const actual = testTemplate(exampleTemplate, {
 			options: { version: "20.12.2" },
 		});
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #211
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/bingo/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/bingo/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Also fixes `produceTemplate` and `testTemplate` to not be async. They don't need auth in their system contexts.

💝 