### PR TITLE
[PoC] feat: switch input args to arrays

### DIFF
--- a/packages/bingo-testers/src/testInput.test.ts
+++ b/packages/bingo-testers/src/testInput.test.ts
@@ -5,17 +5,15 @@ import { z } from "zod";
 import { testInput } from "./testInput.js";
 
 const inputDoubler = createInput({
-	args: {
-		value: z.number(),
-	},
+	args: [z.number()],
 	produce({ args }) {
-		return args.value * 2;
+		return args[0] * 2;
 	},
 });
 
 describe("testInput", () => {
 	it("forwards args to the input", () => {
-		const actual = testInput(inputDoubler, { args: { value: 2 } });
+		const actual = testInput(inputDoubler, { args: [2] });
 
 		expect(actual).toEqual(4);
 	});

--- a/packages/bingo-testers/src/testInput.ts
+++ b/packages/bingo-testers/src/testInput.ts
@@ -1,4 +1,4 @@
-import { AnyShape, InferredObject, Input, TakeInput } from "bingo";
+import { AnyShapesArray, InferredValues, Input, TakeInput } from "bingo";
 
 import { createMockSystems } from "./createMockSystems.js";
 import { MockSystemOptions } from "./types.js";
@@ -12,16 +12,16 @@ export interface InputContextSettingsWithoutArgs extends MockSystemOptions {
 	take?: TakeInput;
 }
 
-export function testInput<Result, ArgsShape extends AnyShape>(
+export function testInput<Result, ArgsShape extends AnyShapesArray>(
 	input: Input<Result, ArgsShape>,
 	settings: Partial<
-		InputContextSettingsWithArgs<InferredObject<ArgsShape>>
+		InputContextSettingsWithArgs<InferredValues<ArgsShape>>
 	> = {},
 ) {
 	const { system, take } = createMockSystems(settings);
 
 	return input({
-		...(settings as InputContextSettingsWithArgs<InferredObject<ArgsShape>>),
+		...(settings as InputContextSettingsWithArgs<InferredValues<ArgsShape>>),
 		...system,
 		take,
 	});

--- a/packages/bingo/src/creators/createInput.test.ts
+++ b/packages/bingo/src/creators/createInput.test.ts
@@ -25,20 +25,16 @@ describe("createInput", () => {
 		expect(actual).toBe(expected);
 	});
 
-	test("production with args", () => {
-		const expected = 234;
+	test("production with one arg", () => {
+		const added = 234;
 
 		const input = createInput({
-			args: {
-				offset: z.number(),
-			},
-			produce: ({ args }) => expected + args.offset,
+			args: [z.number()],
+			produce: ({ args }) => added + args[0],
 		});
 
 		const actual = input({
-			args: {
-				offset: 1000,
-			},
+			args: [1000],
 			fetchers: createSystemFetchers({ fetch: vi.fn() }),
 			fs: {
 				readDirectory: vi.fn(),

--- a/packages/bingo/src/options.ts
+++ b/packages/bingo/src/options.ts
@@ -7,10 +7,16 @@ export type AnyOptionalShape = Record<
 
 export type AnyShape = z.ZodRawShape;
 
+export type AnyShapesArray = [z.ZodType, ...z.ZodType[]];
+
 export type InferredObject<OptionsShape extends AnyShape | undefined> =
 	OptionsShape extends AnyShape
 		? z.infer<z.ZodObject<OptionsShape>>
 		: undefined;
+
+export type InferredValues<ArgsShapes extends AnyShapesArray> = {
+	[K in keyof ArgsShapes]: z.infer<ArgsShapes[K]>;
+};
 
 export type MinimumOptionsShape = AnyOptionalShape & RequiredOptionsShape;
 

--- a/packages/bingo/src/runners/runInput.test.ts
+++ b/packages/bingo/src/runners/runInput.test.ts
@@ -6,20 +6,18 @@ import { createInput } from "../creators/createInput.js";
 import { runInput } from "./runInput.js";
 
 const input = createInput({
-	args: {
-		value: z.number(),
-	},
+	args: [z.number()],
 	async produce({ args, runner }) {
 		return {
 			directory: (await runner("pwd")).stdout,
-			doubled: args.value * 2,
+			doubled: args[0] * 2,
 		};
 	},
 });
 
 describe("runInput", () => {
 	it("defaults directory to '.' when not provided", async () => {
-		const actual = await runInput(input, { args: { value: 2 } });
+		const actual = await runInput(input, { args: [2] });
 
 		expect(actual).toEqual({
 			directory: process.cwd(),
@@ -31,7 +29,7 @@ describe("runInput", () => {
 		const directory = path.join(process.cwd(), "..");
 
 		const actual = await runInput(input, {
-			args: { value: 2 },
+			args: [2],
 			directory,
 		});
 

--- a/packages/bingo/src/runners/runInput.ts
+++ b/packages/bingo/src/runners/runInput.ts
@@ -1,7 +1,7 @@
 import { BingoSystem } from "bingo-systems";
 
 import { createSystemContext } from "../contexts/createSystemContext.js";
-import { AnyShape, InferredObject } from "../options.js";
+import { AnyShapesArray, InferredValues } from "../options.js";
 import { Input } from "../types/inputs.js";
 
 export interface RunInputSettings<Args extends object = object>
@@ -12,9 +12,9 @@ export interface RunInputSettings<Args extends object = object>
 	offline?: boolean;
 }
 
-export function runInput<Result, ArgsShape extends AnyShape>(
+export function runInput<Result, ArgsShape extends AnyShapesArray>(
 	input: Input<Result, ArgsShape>,
-	settings: RunInputSettings<InferredObject<ArgsShape>>,
+	settings: RunInputSettings<InferredValues<ArgsShape>>,
 ) {
 	const system = createSystemContext({
 		directory: settings.directory ?? ".",

--- a/packages/bingo/src/types/inputs.ts
+++ b/packages/bingo/src/types/inputs.ts
@@ -1,11 +1,11 @@
 import { ReadingFileSystem, SystemFetchers, SystemRunner } from "bingo-systems";
 
-import { AnyShape, InferredObject } from "../options.js";
+import { AnyShapesArray, InferredValues } from "../options.js";
 
 export type Input<
 	Result,
-	ArgsShape extends AnyShape | undefined = undefined,
-> = ArgsShape extends AnyShape
+	ArgsShape extends AnyShapesArray | undefined,
+> = ArgsShape extends object
 	? InputWithArgs<Result, ArgsShape>
 	: InputWithoutArgs<Result>;
 
@@ -22,25 +22,25 @@ export interface InputContextWithArgs<Args extends object>
 	args: Args;
 }
 
-export type InputProducerWithArgs<Result, ArgsSchema extends AnyShape> = (
-	context: InputContextWithArgs<InferredObject<ArgsSchema>>,
+export type InputProducerWithArgs<Result, Args extends unknown[]> = (
+	context: InputContextWithArgs<Args>,
 ) => Result;
 
 export type InputProducerWithoutArgs<Result> = (
 	context: InputContext,
 ) => Result;
 
-export interface InputWithArgs<Result, ArgsSchema extends AnyShape> {
-	(context: InputContextWithArgs<InferredObject<ArgsSchema>>): Result;
+export interface InputWithArgs<Result, ArgsSchema extends AnyShapesArray> {
+	(context: InputContextWithArgs<InferredValues<ArgsSchema>>): Result;
 	args: ArgsSchema;
 }
 
 export type InputWithoutArgs<Result> = (context: InputContext) => Result;
 
 export interface TakeInput {
-	<Result, ArgsShape extends AnyShape>(
+	<Result, ArgsShape extends AnyShapesArray>(
 		input: InputWithArgs<Result, ArgsShape>,
-		args: InferredObject<ArgsShape>,
+		...args: InferredValues<ArgsShape>
 	): Result;
 	<Result>(input: InputWithoutArgs<Result>): Result;
 }

--- a/packages/input-from-fetch/README.md
+++ b/packages/input-from-fetch/README.md
@@ -16,17 +16,16 @@ npm i input-from-fetch
 ```ts
 import { inputFromScript } from "input-from-fetch";
 
-await take(inputFromScript, { command: "https://example.com" });
+await take(inputFromScript, "https://example.com");
 ```
 
 ## Options
 
-`inputFromFetch` defines two parameters:
+`inputFromFetch` defines one parameters:
 
-- `resource` _(required)_: the `string` or [`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request) to be passed to [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API)
-- `options` _(optional)_: the [`RequestInit`](https://developer.mozilla.org/en-US/docs/Web/API/RequestInit) object to be passed to [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API)
+- `resource` _(required)_: the `string` to be passed to [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API)
 
-It sends a request to the `resource` with [Input Context `fetch`](https://create.bingo/build/details/contexts#input-fetchers) and returns either:
+It sends a request to the `resource` with [Input Context `fetch`](https://create.bingo/build/details/contexts#input-fetchers) and returns a Promise for either:
 
 - `undefined`: If the [`offline`](https://create.bingo/cli#--offline) flag is enabled
 - [`Error`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error): If an error was caught running the fetch

--- a/packages/input-from-fetch/src/index.test.ts
+++ b/packages/input-from-fetch/src/index.test.ts
@@ -10,7 +10,7 @@ describe("inputFromFetch", () => {
 		const fetch = vi.fn().mockResolvedValue(expected);
 
 		const actual = await testInput(inputFromFetch, {
-			args: { resource },
+			args: [resource],
 			fetchers: createMockFetchers(fetch),
 		});
 

--- a/packages/input-from-fetch/src/index.ts
+++ b/packages/input-from-fetch/src/index.ts
@@ -2,21 +2,21 @@ import { createInput } from "bingo";
 import { z } from "zod";
 
 export const inputFromFetch = createInput({
-	args: {
-		options: z
+	args: [
+		z.string(),
+		z
 			.object({
 				// TODO: fill out!
 			})
-			.optional(),
-		resource: z.string(),
-	},
+			.default({}),
+	],
 	async produce({ args, fetchers, offline }) {
 		if (offline) {
 			return undefined;
 		}
 
 		try {
-			return await fetchers.fetch(args.resource, args.options);
+			return await fetchers.fetch(args[0], args[1]);
 		} catch (error) {
 			return error as Error;
 		}

--- a/packages/input-from-file-json/README.md
+++ b/packages/input-from-file-json/README.md
@@ -16,14 +16,14 @@ npm i input-from-file-json
 ```ts
 import { inputFromFileJSON } from "input-from-file-json";
 
-await take(inputFromFileJSON, { filePath: "data.json" });
+await take(inputFromFileJSON, "data.json");
 ```
 
 ## Options
 
 `inputFromFileJSON` takes a single argument, `filePath`, of type `string`.
 
-It reads the `filePath` from disk and returns either:
+It reads the `filePath` from disk and returns a Promise for either:
 
 - [`Error`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error): If an error was caught reading or parsing the file
 - `unknown`: The result of running `JSON.parse` on the file's text contents

--- a/packages/input-from-file-json/src/index.test.ts
+++ b/packages/input-from-file-json/src/index.test.ts
@@ -8,9 +8,7 @@ describe("inputFromFileJSON", () => {
 		const data = { value: "abc123" };
 
 		const actual = await testInput(inputFromFileJSON, {
-			args: {
-				filePath: "file.txt",
-			},
+			args: ["file.txt"],
 			take: () => Promise.resolve(JSON.stringify(data)),
 		});
 
@@ -21,9 +19,7 @@ describe("inputFromFileJSON", () => {
 		const error = new Error("Oh no!");
 
 		const actual = await testInput(inputFromFileJSON, {
-			args: {
-				filePath: "file.txt",
-			},
+			args: ["file.txt"],
 			take: () => error,
 		});
 
@@ -32,9 +28,7 @@ describe("inputFromFileJSON", () => {
 
 	it("returns the parsing error when inputFromFile resolves with non-parsable string", async () => {
 		const actual = await testInput(inputFromFileJSON, {
-			args: {
-				filePath: "file.txt",
-			},
+			args: ["file.txt"],
 			take: () => Promise.resolve("invalid"),
 		});
 

--- a/packages/input-from-file-json/src/index.ts
+++ b/packages/input-from-file-json/src/index.ts
@@ -4,7 +4,7 @@ import { inputFromFile } from "input-from-file";
 export const inputFromFileJSON = createInput({
 	args: inputFromFile.args,
 	async produce({ args, take }) {
-		const text = await take(inputFromFile, args);
+		const text = await take(inputFromFile, ...args);
 
 		if (text instanceof Error) {
 			return text;

--- a/packages/input-from-file/README.md
+++ b/packages/input-from-file/README.md
@@ -16,14 +16,14 @@ npm i input-from-file
 ```ts
 import { inputFromFile } from "input-from-file";
 
-await take(inputFromFile, { filePath: "data.txt" });
+await take(inputFromFile, "data.txt");
 ```
 
 ## Options
 
 `inputFromFile` takes a single argument, `filePath`, of type `string`.
 
-It reads the `filePath` from disk and returns either:
+It reads the `filePath` from disk and returns a Promise for either:
 
 - [`Error`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error): If an error was caught reading the file
 - `string`: The text contents of the file

--- a/packages/input-from-file/src/index.test.ts
+++ b/packages/input-from-file/src/index.test.ts
@@ -8,9 +8,7 @@ describe("inputFromFile", () => {
 		const text = "abc123";
 
 		const actual = await testInput(inputFromFile, {
-			args: {
-				filePath: "file.txt",
-			},
+			args: ["file.txt"],
 			fs: {
 				readFile: () => Promise.resolve(text),
 			},
@@ -22,9 +20,7 @@ describe("inputFromFile", () => {
 	it("returns an error when reading the file rejects with an error", async () => {
 		const error = new Error("Oh no!");
 		const actual = await testInput(inputFromFile, {
-			args: {
-				filePath: "file.txt",
-			},
+			args: ["file.txt"],
 			fs: {
 				readFile: () => Promise.reject(error),
 			},
@@ -36,9 +32,7 @@ describe("inputFromFile", () => {
 	it("returns an error when reading the file rejects with a string", async () => {
 		const error = new Error("Oh no!");
 		const actual = await testInput(inputFromFile, {
-			args: {
-				filePath: "file.txt",
-			},
+			args: ["file.txt"],
 			fs: {
 				// eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
 				readFile: () => Promise.reject(error.message),

--- a/packages/input-from-file/src/index.ts
+++ b/packages/input-from-file/src/index.ts
@@ -2,12 +2,10 @@ import { createInput } from "bingo";
 import { z } from "zod";
 
 export const inputFromFile = createInput({
-	args: {
-		filePath: z.string(),
-	},
+	args: [z.string()],
 	async produce({ args, fs }) {
 		try {
-			return await fs.readFile(args.filePath);
+			return await fs.readFile(args[0]);
 		} catch (error) {
 			return error instanceof Error ? error : new Error(error as string);
 		}

--- a/packages/input-from-script/README.md
+++ b/packages/input-from-script/README.md
@@ -14,16 +14,16 @@ npm i input-from-script
 ```
 
 ```ts
-import { inputFromFetch } from "input-from-script";
+import { inputFromScript } from "input-from-script";
 
-await take(inputFromFetch, { resource: "npm whoami" });
+await take(inputFromScript, "npm whoami");
 ```
 
 ## Options
 
 `inputFromScript` takes a single argument, `command`, of type `string`.
 
-It runs the `command` with [`execa`](https://www.npmjs.com/package/execa) and returns either:
+It runs the `command` with [`execa`](https://www.npmjs.com/package/execa) and returns a Promise for either:
 
 - [`Error`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error): If an error was caught running the script
 - `Result`: The type from `execa`, including the `stdout` property

--- a/packages/input-from-script/src/index.test.ts
+++ b/packages/input-from-script/src/index.test.ts
@@ -10,7 +10,7 @@ describe("inputFromScript", () => {
 		const runner = vi.fn().mockResolvedValue(expected);
 
 		const actual = await testInput(inputFromScript, {
-			args: { command },
+			args: [command],
 			runner,
 		});
 

--- a/packages/input-from-script/src/index.ts
+++ b/packages/input-from-script/src/index.ts
@@ -2,10 +2,8 @@ import { createInput } from "bingo";
 import { z } from "zod";
 
 export const inputFromScript = createInput({
-	args: {
-		command: z.string(),
-	},
+	args: [z.string()],
 	async produce({ args, runner }) {
-		return await runner(args.command);
+		return await runner(args[0]);
 	},
 });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: ~fixes~ reference for #190
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/bingo/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/bingo/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Reference of what it would look like to have Input args be defined as an array. This would allow consumers to pass them directly like function args, which is more succinct than the current objects:

```diff
- await take(inputFromFile, { command: "data.txt" });
+ await take(inputFromFile, "data.txt");
```

Ultimately I don't think I want to go with this. I like how it's more succinct but don't like how the declarations lose nice object property names. I think I'll just go with the other parts of #190 around making `take` act like `lazy-value`.

@Andarist helped me debug some type inference issues with args, much appreciated 😄 ~

Co-authored-by: @Andarist