### PR TITLE
fix(bingo-systems): rm files before writing them

### DIFF
--- a/packages/bingo-systems/src/files/createWritingFileSystem.test.ts
+++ b/packages/bingo-systems/src/files/createWritingFileSystem.test.ts
@@ -3,11 +3,15 @@ import { describe, expect, it, vi } from "vitest";
 import { createWritingFileSystem } from "./createWritingFileSystem.js";
 
 const mockMkdir = vi.fn();
+const mockRm = vi.fn();
 const mockWriteFile = vi.fn();
 
 vi.mock("node:fs/promises", () => ({
 	get mkdir() {
 		return mockMkdir;
+	},
+	get rm() {
+		return mockRm;
 	},
 	get writeFile() {
 		return mockWriteFile;
@@ -32,7 +36,16 @@ describe("createWritingFileSystem", () => {
 	});
 
 	describe("writeFile", () => {
-		it("writes without mode when options does not exist", async () => {
+		it("writes without mode when options does not exist and rm rejects", async () => {
+			mockRm.mockRejectedValueOnce(new Error("Oh no!"));
+			const system = createWritingFileSystem();
+
+			await system.writeFile(filePath, contents);
+
+			expect(mockWriteFile).toHaveBeenCalledWith(filePath, contents, undefined);
+		});
+
+		it("writes without mode when options does not exist and rm does not reject", async () => {
 			const system = createWritingFileSystem();
 
 			await system.writeFile(filePath, contents);

--- a/packages/bingo-systems/src/files/createWritingFileSystem.ts
+++ b/packages/bingo-systems/src/files/createWritingFileSystem.ts
@@ -13,6 +13,17 @@ export function createWritingFileSystem() {
 			contents: string,
 			options?: CreatedFileMetadata,
 		) => {
+			try {
+				// If the file had custom permissions written, it might support
+				// being deleted but not being written to.
+				// https://github.com/JoshuaKGoldberg/bingo/issues/238
+				await fs.rm(filePath);
+			} catch {
+				// If the file didn't exist, that's fine too.
+				// Or if we don't have rm permissions, we probably won't have
+				// write permissions, so the subsequent writeFile will fail.
+			}
+
 			await fs.writeFile(
 				filePath,
 				contents,


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #238
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/bingo/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/bingo/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds an `fs.rm` call before `fs.writeFile`, swallowing any errors. I found that on my Node.js created files have permissions to read and delete but not to move or write. 🤷 

In theory, this isn't great for performance. I don't love ~doubling the number of `fs.*` APIs called per file.

In practice, there really shouldn't be more than a few dozen files to write in any given template for common use cases. We can cross that performance bridge when we get to it.

💝 