### PR TITLE
fix(bingo): preserve silent mode when merging script commands

### DIFF
--- a/packages/bingo/src/mergers/mergeScripts.test.ts
+++ b/packages/bingo/src/mergers/mergeScripts.test.ts
@@ -4,19 +4,6 @@ import { mergeScripts } from "./mergeScripts.js";
 
 describe("mergeScripts", () => {
 	test.each([
-		[
-			[
-				{ commands: ["rm CONTRIBUTING.md"], phase: 0 },
-				{ commands: ["rm CODE_OF_CONDUCT.md"], phase: 0 },
-				{ commands: ["rm DEVELOPMENT.md"], phase: 0 },
-			],
-			[{ commands: ["rm DEVELOPMENT.md"], phase: 0 }],
-			[
-				{ commands: ["rm CONTRIBUTING.md"], phase: 0 },
-				{ commands: ["rm CODE_OF_CONDUCT.md"], phase: 0 },
-				{ commands: ["rm DEVELOPMENT.md"], phase: 0 },
-			],
-		],
 		[[], [], []],
 		[[], ["a"], ["a"]],
 		[["a"], [], ["a"]],
@@ -362,6 +349,72 @@ describe("mergeScripts", () => {
 					commands: ["pnpm lint"],
 					phase: 1,
 				},
+			],
+		],
+		[
+			[
+				{ commands: ["rm CODE_OF_CONDUCT.md"], phase: 0 },
+				{ commands: ["rm DEVELOPMENT.md"], phase: 0 },
+			],
+			[{ commands: ["rm DEVELOPMENT.md"], phase: 0 }],
+			[
+				{ commands: ["rm CODE_OF_CONDUCT.md"], phase: 0 },
+				{ commands: ["rm DEVELOPMENT.md"], phase: 0 },
+			],
+		],
+		[
+			[
+				{ commands: ["rm CONTRIBUTING.md"], phase: 0 },
+				{ commands: ["rm CODE_OF_CONDUCT.md"], phase: 0 },
+				{ commands: ["rm DEVELOPMENT.md"], phase: 0 },
+			],
+			[{ commands: ["rm DEVELOPMENT.md"], phase: 0 }],
+			[
+				{ commands: ["rm CONTRIBUTING.md"], phase: 0 },
+				{ commands: ["rm CODE_OF_CONDUCT.md"], phase: 0 },
+				{ commands: ["rm DEVELOPMENT.md"], phase: 0 },
+			],
+		],
+		[
+			[
+				{ commands: ["rm CONTRIBUTING.md"], phase: 0, silent: true },
+				{ commands: ["pnpm install"], phase: 1 },
+			],
+			[{ commands: ["rm .prettierrc*"], phase: 0 }],
+			[
+				{ commands: ["rm CONTRIBUTING.md"], phase: 0, silent: true },
+				{ commands: ["rm .prettierrc*"], phase: 0 },
+				{ commands: ["pnpm install"], phase: 1 },
+			],
+		],
+		[
+			[
+				{ commands: ["rm CONTRIBUTING.md"], phase: 0, silent: true },
+				{ commands: ["rm .eslintrc*"], phase: 0, silent: true },
+			],
+			[{ commands: ["rm .prettierrc* prettier.config*"], phase: 0 }],
+			[
+				{ commands: ["rm CONTRIBUTING.md"], phase: 0, silent: true },
+				{ commands: ["rm .eslintrc*"], phase: 0, silent: true },
+				{ commands: ["rm .prettierrc* prettier.config*"], phase: 0 },
+			],
+		],
+		[
+			[
+				{ commands: ["rm CONTRIBUTING.md"], phase: 0, silent: true },
+				{ commands: ["rm .eslintrc*"], phase: 0, silent: true },
+				{ commands: ["pnpm install", "pnpm dedupe --offline"], phase: 1 },
+			],
+			[
+				{ commands: ["pnpm format --write"], phase: 2 },
+				{ commands: ["rm .prettierrc* prettier.config*"], phase: 0 },
+			],
+			[
+				{ commands: ["rm CONTRIBUTING.md"], phase: 0, silent: true },
+				{ commands: ["rm .eslintrc*"], phase: 0, silent: true },
+				{ commands: ["rm .prettierrc* prettier.config*"], phase: 0 },
+				{ commands: ["pnpm install", "pnpm dedupe --offline"], phase: 1 },
+				{ commands: ["pnpm format --write"], phase: 2 },
 			],
 		],
 	])("%j and %j", (first, second, expected) => {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #239
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/bingo/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/bingo/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Previously, the `silent` attribute was preserved at the `phase` level. If any script in a phase wasn't `silent` then the entire `phase` wouldn't be either (`nonSilentPhases`). In other words, _all_ scripts in a `phase` needed to be `silent` for the `phase` to be.

Now, when multiple script objects with the same `phase` are merged, the `silent` attribute factors in `phase` for its caching. 

💝 