### PR TITLE
fix(bingo): use full Clack display in CLI, and log error stacks

### DIFF
--- a/packages/bingo/src/cli/loggers/logOutro.ts
+++ b/packages/bingo/src/cli/loggers/logOutro.ts
@@ -16,8 +16,14 @@ export function logOutro(
 		for (const [group, groupItems] of Object.entries(items)) {
 			for (const [id, item] of Object.entries(groupItems)) {
 				if (item.error) {
-					prompts.log.warn(
-						`The ${chalk.red(id)} ${group} failed. You should re-run it and fix its complaints.\n${item.error as string}`,
+					const error =
+						item.error instanceof Error
+							? // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+								item.error.stack!
+							: (item.error as string);
+
+					prompts.log.error(
+						`The ${chalk.red(id)} ${group} failed. You should re-run it and fix its complaints.\n${error}`,
 					);
 				}
 			}

--- a/packages/bingo/src/cli/setup/runModeSetup.ts
+++ b/packages/bingo/src/cli/setup/runModeSetup.ts
@@ -61,6 +61,7 @@ export async function runModeSetup<OptionsShape extends AnyShape>({
 
 	const system = await createSystemContextWithAuth({
 		directory,
+		display,
 		offline,
 	});
 

--- a/packages/bingo/src/cli/transition/runModeTransition.ts
+++ b/packages/bingo/src/cli/transition/runModeTransition.ts
@@ -47,6 +47,7 @@ export async function runModeTransition<OptionsShape extends AnyShape>({
 
 	const system = await createSystemContextWithAuth({
 		directory,
+		display,
 		offline,
 	});
 

--- a/packages/bingo/src/contexts/createSystemContextWithAuth.ts
+++ b/packages/bingo/src/contexts/createSystemContextWithAuth.ts
@@ -8,7 +8,7 @@ import {
 export async function createSystemContextWithAuth(
 	settings: Pick<
 		SystemContextSettings,
-		"auth" | "directory" | "fetchers" | "offline"
+		"auth" | "directory" | "display" | "fetchers" | "offline"
 	>,
 ) {
 	const authToken =


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #236
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/bingo/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/bingo/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Resolves two issues that were causing #236:

1. The full `ClackDisplay` set up by the CLI wasn't being passed into the setup or transition mode runners, so a new default display (`createDisplay()`) was being used instead
2. `Error` errors were just being logged as strings, so their call stacks would be missed

With just the first fix, errors report like:

```plaintext
┌  ✨ create-typescript-app@2.0.0-beta.17 ✨
│
●  Learn more on:
│    https://github.com/JoshuaKGoldberg/create-typescript-app
│
│  Running with mode --transition using the template:
│    create-typescript-app
│
◇  Ran create-typescript-app
│
▲  The branch-ruleset request failed. You should re-run it and fix its complaints.
│  Error: Oh no!
```

With both fixes, errors report like:

```plaintext
┌  ✨ create-typescript-app@2.0.0-beta.17 ✨
│
●  Learn more on:
│    https://github.com/JoshuaKGoldberg/create-typescript-app
│
│  Running with mode --transition using the template:
│    create-typescript-app
│
◇  Ran create-typescript-app
│
▲  The branch-ruleset request failed. You should re-run it and fix its complaints.
│  Error: Oh no!
│      at Object.send (file:///Users/josh/repos/create-typescript-app/lib/blocks/blockRepositoryBranchRuleset.js:18:21)
│      at file:///Users/josh/repos/bingo/packages/bingo/lib/runners/applyRequestsToSystem.js:5:27
│      at Array.map (<anonymous>)
│      at applyRequestsToSystem (file:///Users/josh/repos/bingo/packages/bingo/lib/runners/applyRequestsToSystem.js:2:32)
│      at runCreation (file:///Users/josh/repos/bingo/packages/bingo/lib/runners/runCreation.js:12:13)
│      at async runTemplate (file:///Users/josh/repos/bingo/packages/bingo/lib/runners/runTemplate.js:13:5)
│      at async file:///Users/josh/repos/bingo/packages/bingo/lib/cli/transition/runModeTransition.js:44:98
│      at async tryCatchError (file:///Users/josh/repos/bingo/packages/bingo/lib/utils/tryCatch.js:3:16)
│      at async runSpinnerTask (file:///Users/josh/repos/bingo/packages/bingo/lib/cli/display/runSpinnerTask.js:6:20)
│      at async runModeTransition (file:///Users/josh/repos/bingo/packages/bingo/lib/cli/transition/runModeTransition.js:44:22)
```

Also switches the complaint from `warn` to `error`, since it's really an _error_.

💝 