### PR TITLE
fix(bingo): wait until repository labels exist for newly created repo

### DIFF
--- a/packages/bingo/src/cli/setup/createRepositoryOnGitHub.ts
+++ b/packages/bingo/src/cli/setup/createRepositoryOnGitHub.ts
@@ -28,4 +28,21 @@ export async function createRepositoryOnGitHub(
 			});
 		}
 	}
+
+	// GitHub asynchronously initializes default repo metadata such as labels.
+	// There's no built-in API to determine whether initialization is done,
+	// but we can approximate that by polling for whether labels are created.
+	// https://github.com/JoshuaKGoldberg/bingo/issues/243
+	// On the off chance the repository's organization has no default labels,
+	// we only retry up to 10 times.
+	for (let i = 0; i < 10; i += 1) {
+		const response = await octokit.request("GET /repos/{owner}/{repo}/labels", {
+			owner: target.owner,
+			repo: target.repository,
+		});
+
+		if (response.data.length) {
+			break;
+		}
+	}
 }


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #243
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/bingo/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/bingo/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Polls the repository label API up to 10 times to try to wait until it's done being initialized.

💝 