### PR TITLE
feat: automatic --exclude-* options for Stratum Blocks

### DIFF
--- a/packages/bingo-stratum/src/creators/createStratumTemplate.test.ts
+++ b/packages/bingo-stratum/src/creators/createStratumTemplate.test.ts
@@ -21,34 +21,69 @@ const preset = base.createPreset({
 	about: { name: "Example" },
 	blocks: [],
 });
-
-const template = base.createStratumTemplate({
-	presets: [preset],
-});
-
 const mockLog = vi.fn();
 
 const mockOptions = { name: "Test Name" };
 
 describe("createStratumTemplate", () => {
 	describe("options", () => {
+		it("does not add block exclusion options when no blocks are named", () => {
+			const template = base.createStratumTemplate({
+				presets: [
+					base.createPreset({
+						about: { name: "Example" },
+						blocks: [base.createBlock({ produce: vi.fn() })],
+					}),
+				],
+			});
+
+			expect(Object.keys(template.options)).toEqual(["name", "preset"]);
+		});
+
+		it("adds a block exclusion option when a block is named", () => {
+			const template = base.createStratumTemplate({
+				presets: [
+					base.createPreset({
+						about: { name: "Example Preset" },
+						blocks: [
+							base.createBlock({
+								about: { name: "Example Block" },
+								produce: vi.fn(),
+							}),
+						],
+					}),
+				],
+			});
+
+			expect(Object.keys(template.options)).toEqual([
+				"name",
+				"preset",
+				"exclude-example-block",
+			]);
+		});
+
 		describe("--preset", () => {
+			const templateWithPreset = base.createStratumTemplate({
+				presets: [preset],
+			});
+
 			it("does not call inferPreset when context.files is not provided", async () => {
-				const lazyOptions = template.prepare({
+				const lazyOptions = templateWithPreset.prepare({
 					log: mockLog,
 					options: mockOptions,
 					take: vi.fn(),
 				});
 
-				await awaitLazyProperties(lazyOptions);
+				const options = await awaitLazyProperties(lazyOptions);
 
 				expect(mockInferPreset).not.toHaveBeenCalled();
+				expect(options).toEqual({});
 			});
 
 			it("does not display a log when inferPreset returns undefined", async () => {
 				mockInferPreset.mockReturnValueOnce(undefined);
 
-				const lazyOptions = template.prepare({
+				const lazyOptions = templateWithPreset.prepare({
 					files: {
 						"README.md": "...",
 					},
@@ -57,15 +92,17 @@ describe("createStratumTemplate", () => {
 					take: vi.fn(),
 				});
 
-				await awaitLazyProperties(lazyOptions);
+				const options = await awaitLazyProperties(lazyOptions);
 
 				expect(mockLog).not.toHaveBeenCalled();
+				expect(options).toEqual({});
 			});
 
 			it("displays a log when inferPreset returns a preset", async () => {
-				mockInferPreset.mockReturnValueOnce("example");
+				const presetName = "example";
+				mockInferPreset.mockReturnValueOnce(presetName);
 
-				const lazyOptions = template.prepare({
+				const lazyOptions = templateWithPreset.prepare({
 					files: {
 						"README.md": "...",
 					},
@@ -74,11 +111,12 @@ describe("createStratumTemplate", () => {
 					take: vi.fn(),
 				});
 
-				await awaitLazyProperties(lazyOptions);
+				const options = await awaitLazyProperties(lazyOptions);
 
 				expect(mockLog).toHaveBeenCalledWith(
 					`Detected ${chalk.blue(`--preset example`)} from existing files on disk.`,
 				);
+				expect(options).toEqual({ preset: presetName });
 			});
 		});
 	});

--- a/packages/bingo-stratum/src/creators/inferPreset.ts
+++ b/packages/bingo-stratum/src/creators/inferPreset.ts
@@ -13,7 +13,7 @@ import {
 } from "../producers/produceBlock.js";
 import { Block } from "../types/blocks.js";
 import { Preset } from "../types/presets.js";
-import { slugifyPresetName } from "../utils.ts/slugifyPresetName.js";
+import { slugifyName } from "../utils/slugifyName.js";
 
 export function inferPreset<OptionsShape extends AnyShape, Refinements>(
 	context: Pick<
@@ -58,7 +58,7 @@ export function inferPreset<OptionsShape extends AnyShape, Refinements>(
 		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 		record!.percentage >= 0.35
 			? // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-				slugifyPresetName(record!.preset.about.name)
+				slugifyName(record!.preset.about.name)
 			: undefined
 	);
 }

--- a/packages/bingo-stratum/src/producers/applyBlockRefinements.test.ts
+++ b/packages/bingo-stratum/src/producers/applyBlockRefinements.test.ts
@@ -26,30 +26,68 @@ const blockC = base.createBlock({
 });
 
 describe("applyBlockRefinements", () => {
-	it("returns the initial blocks when no modifications are provided", () => {
+	it("returns the initial blocks when no exclusion options or refinements are provided", () => {
 		const initial = [blockA, blockB];
 
-		const actual = applyBlockRefinements(initial);
+		const actual = applyBlockRefinements(initial, { value: "" });
 
 		expect(actual).toBe(initial);
 	});
 
-	it("returns the initial blocks when modifications are empty", () => {
+	it("returns the initial blocks when no exclusion options are provided and refinements are empty", () => {
 		const initial = [blockA, blockB];
 
-		const actual = applyBlockRefinements(initial, { add: [], exclude: [] });
+		const actual = applyBlockRefinements(
+			initial,
+			{ value: "" },
+			{ add: [], exclude: [] },
+		);
 
 		expect(actual).toBe(initial);
 	});
 
-	it("applies modifications when they exist", () => {
+	it("returns modified blocks when only exclusion options are provided", () => {
 		const initial = [blockA, blockB];
 
-		const actual = applyBlockRefinements(initial, {
-			add: [blockC],
-			exclude: [blockB],
-		});
+		const actual = applyBlockRefinements(
+			initial,
+			{ "exclude-a": true, value: "" },
+			{
+				add: [],
+				exclude: [],
+			},
+		);
+
+		expect(actual).toEqual([blockB]);
+	});
+
+	it("returns modified blocks when only refinements are provided", () => {
+		const initial = [blockA, blockB];
+
+		const actual = applyBlockRefinements(
+			initial,
+			{ value: "" },
+			{
+				add: [blockC],
+				exclude: [blockB],
+			},
+		);
 
 		expect(actual).toEqual([blockA, blockC]);
+	});
+
+	it("returns modified blocks when both exclusion options and refinements are provided", () => {
+		const initial = [blockA, blockB, blockC];
+
+		const actual = applyBlockRefinements(
+			initial,
+			{ "exclude-a": true, value: "" },
+			{
+				add: [],
+				exclude: [blockB],
+			},
+		);
+
+		expect(actual).toEqual([blockC]);
 	});
 });

--- a/packages/bingo-stratum/src/producers/applyBlockRefinements.ts
+++ b/packages/bingo-stratum/src/producers/applyBlockRefinements.ts
@@ -1,23 +1,37 @@
 import { Block } from "../types/blocks.js";
 import { BlockRefinements } from "../types/refinements.js";
+import { createBlockExclusionOption } from "../utils/createBlockExclusionOption.js";
 
 export function applyBlockRefinements<Options extends object>(
-	initial: Block<object | undefined, Options>[],
+	blocksInitial: Block<object | undefined, Options>[],
+	options: Options,
 	{ add = [], exclude = [] }: BlockRefinements<Options> = {},
 ) {
-	if (!add.length && !exclude.length) {
-		return initial;
+	const exclusionOptions = new Set(
+		Object.entries(options)
+			.filter(([key, value]) => key.startsWith("exclude-") && !!value)
+			.map(([key]) => key),
+	);
+
+	if (!add.length && !exclude.length && !exclusionOptions.size) {
+		return blocksInitial;
 	}
 
-	const blocks = new Set(initial);
+	const blocksRefined = new Set(
+		blocksInitial.filter(
+			(block) =>
+				block.about?.name &&
+				!exclusionOptions.has(createBlockExclusionOption(block.about.name)),
+		),
+	);
 
 	for (const added of add) {
-		blocks.add(added);
+		blocksRefined.add(added);
 	}
 
 	for (const excluded of exclude) {
-		blocks.delete(excluded);
+		blocksRefined.delete(excluded);
 	}
 
-	return Array.from(blocks);
+	return Array.from(blocksRefined);
 }

--- a/packages/bingo-stratum/src/producers/producePreset.ts
+++ b/packages/bingo-stratum/src/producers/producePreset.ts
@@ -37,7 +37,11 @@ export function producePreset<OptionsShape extends AnyShape>(
 		refinements = {},
 	}: ProducePresetSettings<OptionsShape>,
 ): BlockCreation<InferredObject<OptionsShape>> {
-	const blocks = applyBlockRefinements(preset.blocks, refinements.blocks);
+	const blocks = applyBlockRefinements(
+		preset.blocks,
+		options,
+		refinements.blocks,
+	);
 
 	const creation = produceBlocks(blocks, {
 		addons: refinements.addons,

--- a/packages/bingo-stratum/src/producers/produceStratumTemplate.ts
+++ b/packages/bingo-stratum/src/producers/produceStratumTemplate.ts
@@ -2,7 +2,7 @@ import { AnyShape, InferredObject, ProductionMode } from "bingo";
 
 import { StratumRefinements } from "../types/refinements.js";
 import { StratumTemplate } from "../types/templates.js";
-import { getPresetByName } from "../utils.ts/getPresetByName.js";
+import { getPresetByName } from "../utils/getPresetByName.js";
 import { applyBlockRefinements } from "./applyBlockRefinements.js";
 import { produceBlocks } from "./produceBlocks.js";
 
@@ -29,7 +29,11 @@ export function produceStratumTemplate<
 		throw preset;
 	}
 
-	const blocks = applyBlockRefinements(preset.blocks, refinements.blocks);
+	const blocks = applyBlockRefinements(
+		preset.blocks,
+		options,
+		refinements.blocks,
+	);
 
 	return produceBlocks(blocks, {
 		addons: refinements.addons,

--- a/packages/bingo-stratum/src/types/templates.ts
+++ b/packages/bingo-stratum/src/types/templates.ts
@@ -35,7 +35,7 @@ export interface StratumTemplateDefinition<OptionsShape extends AnyShape> {
 }
 
 export interface StratumTemplateOptionsShape {
-	preset: z.ZodUnion<ZodPresetNameLiterals>;
+	preset: z.ZodDefault<z.ZodUnion<ZodPresetNameLiterals>>;
 }
 
 export type ZodPresetNameLiterals = [

--- a/packages/bingo-stratum/src/utils/createBlockExclusionOption.ts
+++ b/packages/bingo-stratum/src/utils/createBlockExclusionOption.ts
@@ -1,0 +1,5 @@
+import { slugifyName } from "./slugifyName.js";
+
+export function createBlockExclusionOption(blockName: string) {
+	return `exclude-${slugifyName(blockName)}`;
+}

--- a/packages/bingo-stratum/src/utils/getPresetByName.ts
+++ b/packages/bingo-stratum/src/utils/getPresetByName.ts
@@ -1,7 +1,7 @@
 import { AnyShape } from "bingo";
 
 import { Preset } from "../types/presets.js";
-import { slugifyPresetName } from "./slugifyPresetName.js";
+import { slugifyName } from "./slugifyName.js";
 
 export function getPresetByName<OptionsShape extends AnyShape>(
 	presets: Preset<OptionsShape>[],
@@ -9,12 +9,12 @@ export function getPresetByName<OptionsShape extends AnyShape>(
 ) {
 	const presetsByName = new Map(
 		Array.from(
-			presets.map((preset) => [slugifyPresetName(preset.about.name), preset]),
+			presets.map((preset) => [slugifyName(preset.about.name), preset]),
 		),
 	);
 
 	return (
-		presetsByName.get(slugifyPresetName(requested)) ??
+		presetsByName.get(slugifyName(requested)) ??
 		new Error(
 			`${requested} is not one of: ${Array.from(presetsByName.keys()).join(", ")}`,
 		)

--- a/packages/bingo-stratum/src/utils/slugifyName.ts
+++ b/packages/bingo-stratum/src/utils/slugifyName.ts
@@ -1,6 +1,6 @@
 import slugify from "slugify";
 
-export function slugifyPresetName(original: string) {
+export function slugifyName(original: string) {
 	// @ts-expect-error -- https://github.com/simov/slugify/issues/196
 	return slugify(original, { lower: true }) as string;
 }

--- a/packages/bingo/src/cli/loggers/logSchemasHelpOptions.ts
+++ b/packages/bingo/src/cli/loggers/logSchemasHelpOptions.ts
@@ -8,7 +8,7 @@ export function logSchemasHelpOptions(packageName: string, schemas: AnyShape) {
 		packageName,
 		Object.entries(schemas)
 			.map(([flag, schema]) => ({
-				flag,
+				flag: `--${flag}`,
 				text: asSentence(schema.description),
 				type: getSchemaTypeName(schema),
 			}))

--- a/packages/bingo/src/cli/setup/runModeSetup.ts
+++ b/packages/bingo/src/cli/setup/runModeSetup.ts
@@ -70,11 +70,23 @@ export async function runModeSetup<OptionsShape extends AnyShape, Refinements>({
 	});
 
 	const providedOptions = parseZodArgs(args, template.options);
-	const preparedOptions = await prepareOptions(template, {
-		...system,
-		existing: { ...providedOptions, directory },
-		offline,
-	});
+
+	const preparedOptions = await runSpinnerTask(
+		display,
+		"Inferring default options from system",
+		"Inferred default options from system",
+		async () => {
+			return await prepareOptions(template, {
+				...system,
+				existing: { ...providedOptions, directory },
+				offline,
+			});
+		},
+	);
+	if (preparedOptions instanceof Error) {
+		logRerunSuggestion(args, providedOptions);
+		return { error: preparedOptions, status: CLIStatus.Error };
+	}
 
 	const baseOptions = await promptForOptionSchemas(template, {
 		existing: {

--- a/packages/bingo/src/cli/transition/runModeTransition.ts
+++ b/packages/bingo/src/cli/transition/runModeTransition.ts
@@ -87,7 +87,7 @@ export async function runModeTransition<
 		return { error: loadedConfig, status: CLIStatus.Error };
 	}
 
-	const existingOptions = await runSpinnerTask(
+	const preparedOptions = await runSpinnerTask(
 		display,
 		"Inferring options from existing repository",
 		"Inferred options from existing repository",
@@ -103,13 +103,13 @@ export async function runModeTransition<
 			});
 		},
 	);
-	if (existingOptions instanceof Error) {
+	if (preparedOptions instanceof Error) {
 		logRerunSuggestion(args, providedOptions);
-		return { error: existingOptions, status: CLIStatus.Error };
+		return { error: preparedOptions, status: CLIStatus.Error };
 	}
 
 	const baseOptions = await promptForOptionSchemas(template, {
-		existing: existingOptions,
+		existing: { ...providedOptions, ...preparedOptions },
 		system,
 	});
 	if (baseOptions.cancelled) {

--- a/packages/site/src/content/docs/engines/stratum/concepts/templates.mdx
+++ b/packages/site/src/content/docs/engines/stratum/concepts/templates.mdx
@@ -19,7 +19,7 @@ import { presetMinimal } from "./presetMinimal";
 
 export const template = createTemplate({
 	about: {
-		name: "TypeScript App",
+		name: "Stratum Example",
 	},
 	presets: [
 		{ label: "Minimal", preset: presetMinimal },
@@ -52,19 +52,64 @@ Options declared on a Template's Base are what may be set in a configuration's `
 
 ### `--preset`
 
-The only added option is `preset`, which is a required string option.
+All Stratum Templates include a `--preset`, option which is a required string.
 It is a union of the lowercased labels provided under `presets`.
 
-For example, given the earlier `template` with three Presets, the `preset` option would be type `"common" | "everything" | "minimal"`:
+For example, given the earlier `template` with three Presets, the `--preset` option would be type `"common" | "everything" | "minimal"`:
 
-```ts title="create-example.config.ts"
-import { template } from "create-typescript-app";
+It could be specified on the CLI:
+
+```shell
+npx create-stratum-example --preset everything
+```
+
+Presets can also be specified as a standard option in a configuration file:
+
+```ts title="create-stratum-example.config.ts"
+import { template } from "create-stratum-example";
 
 export default createConfig(template, {
-	options: { preset: "everything" },
+	options: {
+		preset: "everything",
+	},
 });
 ```
 
 During transition mode, Stratum will attempt to infer a default value for `--preset` based using files on disk.
 That default value is computed by comparing existing files on disk to the files that would be produced by the Blocks.
 If Preset with the greatest percentage matches 35% or more of its created files, it will be used as the default.
+
+### Exclusion Options
+
+Stratum Templates also add `--exclude-*` CLI options for each of their named Blocks.
+Each Block name is transformed to kebab-cases boolean option that defaults to `false`.
+
+For example, given the following named `ESLint` Block:
+
+```ts
+import { base } from "./base";
+
+export const blockESLint = base.createBlock({
+	about: {
+		name: "ESLint",
+	},
+	produce() {
+		return {
+			files: {
+				"eslint.config.js": "...",
+			},
+		};
+	},
+});
+```
+
+If a Stratum Template includes that Block, it will have an `--exclude-eslint` option available on the CLI:
+
+```shell
+npx create-stratum-example --exclude-eslint
+```
+
+:::note
+Exclusion options are not added to the TypeScript types of `createConfig` functions in configuration files.
+See [Details > Configurations > Refinements > `exclude`](/engines/stratum/details/configurations#exclude) for excluding Blocks in configuration files.
+:::


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #215
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/bingo/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/bingo/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Auto-generates `exclude-*` options by kebab-casing all available Block names. These are added to all Stratum templates' `options`, so they're available on the CLI as `--exclude-*`.

However, they're intentionally not added to the types of templates, because:

* It'd be a lot of types plumbing to know the full list of Blocks.
* We want to discourage using them in config files: it's better to instead use imported Blocks in `refinements.blocks.exclude`.

Also fixes an issue in Bingo around provided options not being factored in after preparation.

💝 