### PR TITLE
fix(bingo): corrected re-run commands and deduplicated error logging

### DIFF
--- a/packages/bingo/src/cli/display/runInsideClackDisplay.ts
+++ b/packages/bingo/src/cli/display/runInsideClackDisplay.ts
@@ -33,7 +33,7 @@ export async function runInsideClackDisplay(
 		return results;
 	}
 
-	if (results.status === CLIStatus.Error) {
+	if (results.status === CLIStatus.Error && results.error) {
 		prompts.log.error(chalk.red(`Error: ${results.error.message}`));
 	}
 

--- a/packages/bingo/src/cli/loggers/logRerunSuggestion.test.ts
+++ b/packages/bingo/src/cli/loggers/logRerunSuggestion.test.ts
@@ -14,19 +14,21 @@ vi.mock("@clack/prompts", () => ({
 
 describe("logRerunSuggestion", () => {
 	it("does not log when there are no prompted entries", () => {
-		logRerunSuggestion(["my-app"], {});
+		logRerunSuggestion([".../node", ".../my-app"], {});
 
 		expect(mockLog.info).not.toHaveBeenCalled();
 	});
 
-	it("logs when there are no prompted entries", () => {
-		logRerunSuggestion(["my-app"], { abc: "def" });
+	it("logs when there are prompted entries", () => {
+		logRerunSuggestion([".../node", ".../my-app"], {
+			abc: "def",
+		});
 
 		expect(mockLog.info).toHaveBeenCalled();
 	});
 
 	test("value stringification", () => {
-		logRerunSuggestion(["my-app"], {
+		logRerunSuggestion([".../node", ".../my-app"], {
 			"is-false": false,
 			"is-true": true,
 			multiple: ["def", 456],
@@ -38,7 +40,7 @@ describe("logRerunSuggestion", () => {
 		expect(mockLog.info.mock.calls).toMatchInlineSnapshot(`
 			[
 			  [
-			    "Tip: to run again with the same input values, use: npx bingo my-app --is-false false --is-true --multiple def --multiple 456 --numeric 123 --spaced "a bb ccc" --stringy abc",
+			    "Tip: to run again with the same input values, use: npx my-app --is-false false --is-true --multiple def --multiple 456 --numeric 123 --spaced "a bb ccc" --stringy abc",
 			  ],
 			]
 		`);

--- a/packages/bingo/src/cli/loggers/logRerunSuggestion.ts
+++ b/packages/bingo/src/cli/loggers/logRerunSuggestion.ts
@@ -1,7 +1,7 @@
 import * as prompts from "@clack/prompts";
 import chalk from "chalk";
 
-export function logRerunSuggestion(args: string[], prompted: object) {
+export function logRerunSuggestion(argv: string[], prompted: object) {
 	const promptedEntries = Object.entries(prompted);
 	if (!promptedEntries.length) {
 		return;
@@ -12,10 +12,9 @@ export function logRerunSuggestion(args: string[], prompted: object) {
 			chalk.italic(`Tip: to run again with the same input values, use:`),
 			chalk.blue(
 				[
-					`npx bingo`,
-					...args,
+					"npx",
+					argv[1].split(/[/\\]/).at(-1),
 					promptedEntries
-
 						.map(([key, value]) => stringifyPair(key, value))
 						.join(" "),
 				].join(" "),

--- a/packages/bingo/src/cli/messages.ts
+++ b/packages/bingo/src/cli/messages.ts
@@ -1,4 +1,7 @@
 export enum CLIMessage {
+	Done = `Done. Enjoy your updated repository! 💝`,
 	Exiting = "Exiting - maybe another time? 👋",
+	Leaving = "Leaving changes to the local directory on disk. 👋",
+	New = `Done. Enjoy your new repository! 💝`,
 	Ok = "Cheers! 💝",
 }

--- a/packages/bingo/src/cli/parseProcessArgv.ts
+++ b/packages/bingo/src/cli/parseProcessArgv.ts
@@ -39,11 +39,10 @@ export interface RunCLIRawValues {
 }
 
 export function parseProcessArgv() {
-	const args = process.argv.slice(2);
 	return {
-		args,
+		argv: process.argv,
 		...parseArgs({
-			args,
+			args: process.argv.slice(2),
 			options: cliArgsOptions,
 			strict: false,
 		}),

--- a/packages/bingo/src/cli/runBingoCLI.ts
+++ b/packages/bingo/src/cli/runBingoCLI.ts
@@ -14,7 +14,7 @@ import { makeRelative } from "./utils.js";
  * @returns CLI status to assign to `process.exitCode`.
  */
 export async function runBingoCLI() {
-	const { args, positionals, values } = parseProcessArgv();
+	const { argv, positionals, values } = parseProcessArgv();
 	if (values.version) {
 		console.log(packageData.version);
 		return CLIStatus.Success;
@@ -34,7 +34,7 @@ export async function runBingoCLI() {
 		}
 
 		const result = await runCLI({
-			args,
+			argv,
 			display,
 			from: `bingo ${from}`,
 			template,

--- a/packages/bingo/src/cli/runCLI.ts
+++ b/packages/bingo/src/cli/runCLI.ts
@@ -21,7 +21,7 @@ const valuesSchema = z.object({
 });
 
 export interface RunCLISettings<OptionsShape extends AnyShape, Refinements> {
-	args: string[];
+	argv: string[];
 	display: ClackDisplay;
 	from: string;
 	template: Template<OptionsShape, Refinements>;
@@ -29,7 +29,7 @@ export interface RunCLISettings<OptionsShape extends AnyShape, Refinements> {
 }
 
 export async function runCLI<OptionsShape extends AnyShape, Refinements>({
-	args,
+	argv,
 	display,
 	from,
 	template,
@@ -47,7 +47,7 @@ export async function runCLI<OptionsShape extends AnyShape, Refinements>({
 
 	const sharedSettings = {
 		...validatedValues,
-		args,
+		argv,
 		display,
 		from,
 		template,

--- a/packages/bingo/src/cli/runCli.test.ts
+++ b/packages/bingo/src/cli/runCli.test.ts
@@ -42,13 +42,15 @@ const template = createTemplate({
 	produce: vi.fn(),
 });
 
+const argv = ["npx", "bingo-example"];
+
 describe("runCli", () => {
 	it("logs the error when readProductionSettings resolves an error", async () => {
 		const error = new Error("Oh no!");
 		mockReadProductionSettings.mockResolvedValueOnce(error);
 
 		const actual = await runCLI({
-			args: [],
+			argv,
 			display: createClackDisplay(),
 			from: "",
 			template,
@@ -65,7 +67,7 @@ describe("runCli", () => {
 		});
 
 		await runCLI({
-			args: [],
+			argv,
 			display: createClackDisplay(),
 			from: "",
 			template,
@@ -83,7 +85,7 @@ describe("runCli", () => {
 		});
 
 		await runCLI({
-			args: [],
+			argv,
 			display: createClackDisplay(),
 			from: "",
 			template,

--- a/packages/bingo/src/cli/runTemplateCLI.ts
+++ b/packages/bingo/src/cli/runTemplateCLI.ts
@@ -34,7 +34,7 @@ export async function runTemplateCLI<
 		return CLIStatus.Error;
 	}
 
-	const { args, values } = parseProcessArgv();
+	const { argv, values } = parseProcessArgv();
 	if (values.version) {
 		console.log(`${packageData.name}@${packageData.version}`);
 		console.log(`${templatePackageData.name}@${templatePackageData.version}`);
@@ -49,7 +49,7 @@ export async function runTemplateCLI<
 		}
 
 		return await runCLI({
-			args,
+			argv,
 			display,
 			from: templatePackageData.name,
 			template,

--- a/packages/bingo/src/cli/transition/runModeTransition.test.ts
+++ b/packages/bingo/src/cli/transition/runModeTransition.test.ts
@@ -141,7 +141,7 @@ const templateWithRepository = createTemplate({
 	produce: vi.fn(),
 });
 
-const args = ["bingo-my-app"];
+const argv = ["npx", "bingo-my-app"];
 
 const from = "create-example";
 
@@ -152,7 +152,7 @@ const promptedOptions = {
 describe("runModeTransition", () => {
 	it("logs help text instead of running when help is true", async () => {
 		await runModeTransition({
-			args,
+			argv,
 			configFile: undefined,
 			display,
 			from,
@@ -169,7 +169,7 @@ describe("runModeTransition", () => {
 		mockReadConfigSettings.mockResolvedValueOnce(error);
 
 		const actual = await runModeTransition({
-			args,
+			argv,
 			configFile: "example.config.ts",
 			display,
 			from,
@@ -180,7 +180,7 @@ describe("runModeTransition", () => {
 			error,
 			status: CLIStatus.Error,
 		});
-		expect(mockLogRerunSuggestion).toHaveBeenCalledWith(args, {});
+		expect(mockLogRerunSuggestion).toHaveBeenCalledWith(argv, {});
 	});
 
 	it("returns the error when prepareOptions throws an error", async () => {
@@ -188,18 +188,15 @@ describe("runModeTransition", () => {
 		mockPrepareOptions.mockRejectedValueOnce(error);
 
 		const actual = await runModeTransition({
-			args,
+			argv,
 			configFile: undefined,
 			display,
 			from,
 			template,
 		});
 
-		expect(actual).toEqual({
-			error,
-			status: CLIStatus.Error,
-		});
-		expect(mockLogRerunSuggestion).toHaveBeenCalledWith(args, {});
+		expect(actual).toEqual({ status: CLIStatus.Error });
+		expect(mockLogRerunSuggestion).toHaveBeenCalledWith(argv, {});
 	});
 
 	it("returns the cancellation when promptForOptions is cancelled", async () => {
@@ -209,7 +206,7 @@ describe("runModeTransition", () => {
 		});
 
 		const actual = await runModeTransition({
-			args,
+			argv,
 			configFile: undefined,
 			display,
 			from,
@@ -219,7 +216,7 @@ describe("runModeTransition", () => {
 		expect(actual).toEqual({
 			status: CLIStatus.Cancelled,
 		});
-		expect(mockLogRerunSuggestion).toHaveBeenCalledWith(args, promptedOptions);
+		expect(mockLogRerunSuggestion).toHaveBeenCalledWith(argv, promptedOptions);
 	});
 
 	it("returns the error when runTemplate resolves with an error", async () => {
@@ -231,7 +228,7 @@ describe("runModeTransition", () => {
 		mockRunTemplate.mockRejectedValueOnce(error);
 
 		const actual = await runModeTransition({
-			args,
+			argv,
 			configFile: undefined,
 			display,
 			from,
@@ -239,11 +236,10 @@ describe("runModeTransition", () => {
 		});
 
 		expect(actual).toEqual({
-			error,
 			outro: `Leaving changes to the local directory on disk. 👋`,
 			status: CLIStatus.Error,
 		});
-		expect(mockLogRerunSuggestion).toHaveBeenCalledWith(args, promptedOptions);
+		expect(mockLogRerunSuggestion).toHaveBeenCalledWith(argv, promptedOptions);
 	});
 
 	it("doesn't clear the existing repository when the template does not have a repository locator", async () => {
@@ -252,7 +248,7 @@ describe("runModeTransition", () => {
 		});
 
 		const actual = await runModeTransition({
-			args,
+			argv,
 			configFile: undefined,
 			display,
 			from,
@@ -265,7 +261,7 @@ describe("runModeTransition", () => {
 		});
 		expect(mockClearTemplateFiles).not.toHaveBeenCalled();
 		expect(mockClearLocalGitTags).not.toHaveBeenCalled();
-		expect(mockLogRerunSuggestion).toHaveBeenCalledWith(args, promptedOptions);
+		expect(mockLogRerunSuggestion).toHaveBeenCalledWith(argv, promptedOptions);
 	});
 
 	it("clears the existing repository online when a forked repository locator is available and offline is falsy", async () => {
@@ -278,7 +274,7 @@ describe("runModeTransition", () => {
 		});
 
 		const actual = await runModeTransition({
-			args,
+			argv,
 			configFile: undefined,
 			display,
 			from,
@@ -301,7 +297,7 @@ describe("runModeTransition", () => {
 			amend: true,
 			push: true,
 		});
-		expect(mockLogRerunSuggestion).toHaveBeenCalledWith(args, promptedOptions);
+		expect(mockLogRerunSuggestion).toHaveBeenCalledWith(argv, promptedOptions);
 	});
 
 	it("clears the existing repository offline when a forked repository locator is available and offline is true", async () => {
@@ -314,7 +310,7 @@ describe("runModeTransition", () => {
 		});
 
 		const actual = await runModeTransition({
-			args,
+			argv,
 			configFile: undefined,
 			display,
 			from,
@@ -338,6 +334,6 @@ describe("runModeTransition", () => {
 			amend: true,
 			push: false,
 		});
-		expect(mockLogRerunSuggestion).toHaveBeenCalledWith(args, promptedOptions);
+		expect(mockLogRerunSuggestion).toHaveBeenCalledWith(argv, promptedOptions);
 	});
 });

--- a/packages/bingo/src/cli/types.ts
+++ b/packages/bingo/src/cli/types.ts
@@ -8,7 +8,7 @@ export interface ModeResultsBase {
 }
 
 export interface ModeResultsError extends ModeResultsBase {
-	error: Error;
+	error?: Error;
 	status: CLIStatus.Error;
 }
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #268
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/bingo/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/bingo/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

`runSpinnerTask` already logs errors, so there's no need to return them as an error to be logged from `runMode*`. This was bugging me.

💝 