### PR TITLE
docs: add links to bingo-examples

### DIFF
--- a/packages/site/src/content/docs/build/about.mdx
+++ b/packages/site/src/content/docs/build/about.mdx
@@ -23,6 +23,7 @@ For example Bingo template repositories, see:
 - [create-example-minimal](https://github.com/bingo-examples/create-example-minimal): The barest bones template as created by this docs page
 - [create-example](https://github.com/bingo-examples/create-example): A larger template with more options and tests
 
+[github.com/bingo-examples](https://github.com/bingo-examples) contains more examples of Bingo templates.
 :::
 
 ### 1. Template File

--- a/packages/site/src/content/docs/build/faqs.mdx
+++ b/packages/site/src/content/docs/build/faqs.mdx
@@ -81,8 +81,6 @@ This is for two reasons:
 - Long-term, the engine should not be locked into any one schema engine.
   Adopting Zod-specific features will make it harder to swap between other implementers of [standard-schema](https://github.com/standard-schema/standard-schema) in the future if needed.
 
-{/* TODO: add link to create-stratum-example's base, once it exists! */}
-
 ### Why is the template `prepare()` function synchronous?
 
 > Or: why must options defaults be provided as asynchronous functions, rather than having `prepare()` itself `await` for their values?

--- a/packages/site/src/content/docs/engines/stratum/about.mdx
+++ b/packages/site/src/content/docs/engines/stratum/about.mdx
@@ -24,6 +24,7 @@ Those layers allow you to define the inputs to your repository template, the ind
 For examples of repository templates built with Stratum, see:
 
 1. [bingo-examples/create-stratum-example-minimal](https://github.com/bingo-examples/create-stratum-example-minimal): The barest bones template
-2. [bingo-examples/create-stratum-example-common](https://github.com/bingo-examples/create-stratum-example-common): A larger template with more options and tests
+2. [bingo-examples/create-stratum-example](https://github.com/bingo-examples/create-stratum-example): A larger template with more options and tests
 
+[github.com/bingo-examples](https://github.com/bingo-examples) contains more examples of Bingo templates.
 :::


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #219
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/bingo/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/bingo/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

As said in the docs now: [github.com/bingo-examples](https://github.com/bingo-examples) contains more examples of Bingo templates.

💝 