### PR TITLE
feat: don't attempt to create repository if not authenticated

### DIFF
--- a/packages/bingo/src/cli/schemas/isStringLikeSchema.test.ts
+++ b/packages/bingo/src/cli/schemas/isStringLikeSchema.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "vitest";
+import { z } from "zod";
+
+import { isStringLikeSchema } from "./isStringLikeSchema.js";
+
+enum Value {
+	A,
+	B,
+	C,
+}
+
+describe("isStringLikeSchema", () => {
+	test.each([
+		["boolean", z.boolean(), true],
+		["boolean literal", z.literal(false), true],
+		["number", z.number(), true],
+		["number literal", z.literal(0), true],
+		["string", z.string(), true],
+		["string literal", z.literal(""), true],
+		[
+			"union of string-likes",
+			z.union([z.boolean(), z.number(), z.string()]),
+			true,
+		],
+		[
+			"union of primitives",
+			z.union([z.literal(false), z.literal(0), z.literal("")]),
+			true,
+		],
+		["default boolean", z.boolean().default(false), true],
+		["default boolean literal", z.literal(false).default(false), true],
+		["default number", z.number().default(0), true],
+		["default number literal", z.literal(0).default(0), true],
+		["default string", z.string().default(""), true],
+		["default string literal", z.literal("").default(""), true],
+		[
+			"default union of string-likes",
+			z.union([z.boolean(), z.number(), z.string()]).default(""),
+			true,
+		],
+		["optional boolean", z.boolean().optional(), true],
+		["optional boolean literal", z.literal(false).optional(), true],
+		["optional number", z.number().optional(), true],
+		["optional number literal", z.literal(0).optional(), true],
+		["optional string", z.string().optional(), true],
+		["optional string literal", z.literal("").optional(), true],
+		[
+			"optional union of string-likes",
+			z.union([z.boolean(), z.number(), z.string()]).optional(),
+			true,
+		],
+		["default optional boolean", z.boolean().default(false).optional(), true],
+		["default optional number", z.number().default(0).optional(), true],
+		["default optional string", z.string().default("").optional(), true],
+		[
+			"default optional union of string-likes",
+			z.union([z.boolean(), z.number(), z.string()]).default("").optional(),
+			true,
+		],
+		["optional default boolean", z.boolean().optional().default(false), true],
+		["optional default number", z.number().optional().default(0), true],
+		["optional default string", z.string().optional().default(""), true],
+		[
+			"optional default union of string-likes",
+			z
+				.union([z.boolean(), z.number(), z.string()])
+				.default("")
+				.optional()
+				.default(""),
+			true,
+		],
+		["enum", z.enum(["a", "b", "c"]), true],
+		["object", z.object({}), false],
+		["default object", z.object({}).default({}), false],
+		["optional object", z.object({}).optional(), false],
+		["default optional object", z.object({}).default({}).optional(), false],
+		["optional default object", z.object({}).optional().default({}), false],
+		["intersection", z.intersection(z.object({}), z.object({})), false],
+		["array", z.array(z.string()), false],
+		["tuple", z.tuple([z.string()]), false],
+		["date", z.date(), false],
+		["native enum", z.nativeEnum(Value), false],
+	])("%s", (_, schema, expected) => {
+		expect(isStringLikeSchema(schema)).toBe(expected);
+	});
+});

--- a/packages/bingo/src/cli/schemas/isStringLikeSchema.ts
+++ b/packages/bingo/src/cli/schemas/isStringLikeSchema.ts
@@ -1,0 +1,26 @@
+import { z } from "zod";
+
+import { PromptFriendlyZodDef } from "./types.js";
+
+export function isStringLikeSchema(schema: z.ZodTypeAny): boolean {
+	const def = schema._def as PromptFriendlyZodDef;
+
+	switch (def.typeName) {
+		case z.ZodFirstPartyTypeKind.ZodBoolean:
+		case z.ZodFirstPartyTypeKind.ZodEnum:
+		case z.ZodFirstPartyTypeKind.ZodLiteral:
+		case z.ZodFirstPartyTypeKind.ZodNumber:
+		case z.ZodFirstPartyTypeKind.ZodString:
+			return true;
+
+		case z.ZodFirstPartyTypeKind.ZodDefault:
+		case z.ZodFirstPartyTypeKind.ZodOptional:
+			return isStringLikeSchema(def.innerType);
+
+		case z.ZodFirstPartyTypeKind.ZodUnion:
+			return def.options.every((option) => isStringLikeSchema(option));
+
+		default:
+			return false;
+	}
+}

--- a/packages/bingo/src/cli/schemas/isZodDefaultDef.test.ts
+++ b/packages/bingo/src/cli/schemas/isZodDefaultDef.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "vitest";
+import { z } from "zod";
+
+import { isZodDefaultDef } from "./isZodDefaultDef.js";
+
+enum Value {
+	A,
+	B,
+	C,
+}
+
+describe("isZodDefaultDef", () => {
+	test.each([
+		["boolean", z.boolean(), false],
+		["default boolean", z.boolean().default(false), true],
+		["boolean literal", z.literal(false), false],
+		["default boolean literal", z.literal(false).default(false), true],
+		["number", z.number(), false],
+		["default number", z.number().default(0), true],
+		["number literal", z.literal(0), false],
+		["default number literal", z.literal(0).default(0), true],
+		["string", z.string(), false],
+		["default string", z.string().default(""), true],
+		["string literal", z.literal(""), false],
+		["default string literal", z.literal("").default(""), true],
+		["enum", z.enum(["a", "b", "c"]), false],
+		["default enum", z.enum(["a", "b", "c"]).default("a"), true],
+		["object", z.object({}), false],
+		["default object", z.object({}).default({}), true],
+		["array", z.array(z.string()), false],
+		["default array", z.array(z.string()).default([]), true],
+		["tuple", z.tuple([z.string()]), false],
+		["default tuple", z.tuple([z.string()]).default([""]), true],
+		["date", z.date(), false],
+		["default date", z.date().default(new Date()), true],
+		["native enum", z.nativeEnum(Value), false],
+		["default native enum", z.nativeEnum(Value).default(Value.A), true],
+	])("%s", (_, schema, expected) => {
+		expect(isZodDefaultDef(schema._def)).toBe(expected);
+	});
+});

--- a/packages/bingo/src/cli/schemas/isZodDefaultDef.ts
+++ b/packages/bingo/src/cli/schemas/isZodDefaultDef.ts
@@ -1,0 +1,9 @@
+// eslint-disable-next-line @eslint-community/eslint-comments/disable-enable-pair
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access */
+import { z } from "zod";
+
+import { ZodDefaultDefWithType } from "./types.js";
+
+export function isZodDefaultDef(def: any): def is ZodDefaultDefWithType {
+	return def.typeName === z.ZodFirstPartyTypeKind.ZodDefault;
+}

--- a/packages/bingo/src/cli/schemas/types.ts
+++ b/packages/bingo/src/cli/schemas/types.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+
+/**
+ * The known Zod schema types that we know how to prompt for with Clack.
+ */
+export type PromptFriendlyZodDef =
+	| z.ZodBooleanDef
+	| z.ZodEnumDef
+	| z.ZodLiteralDef
+	| z.ZodNumberDef
+	| z.ZodOptionalDef
+	| z.ZodStringDef
+	| z.ZodUnionDef
+	| ZodDefaultDefWithType;
+
+/**
+ * Our view of default defs: we access the private innerType and typeName properties.
+ */
+export type ZodDefaultDefWithType = z.ZodDefaultDef & {
+	innerType: z.ZodTypeAny;
+	typeName: z.ZodFirstPartyTypeKind.ZodDefault;
+};


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to Bingo! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #261
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/bingo/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/bingo/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Checks whether the user seems to be logged into GitHub with [`getGitHubAuthToken`](https://github.com/JoshuaKGoldberg/get-github-auth-token), which intentionally is what Bingo elsewhere uses to set up its Octokit instances.

An alternate design could have been to just not have a `system.fetchers.octokit` Octokit instance without auth. I think that's a design that will more likely happen with #275 - and I've noted it there too with https://github.com/JoshuaKGoldberg/bingo/issues/275#issuecomment-2715524221.

Refactors a bit of the Zod schema stuffs to be more shared and tested. One day I will split out a library...

💝 