### PR TITLE
fix: skip calling to GitHub APIs without an auth token

### DIFF
--- a/packages/bingo-systems/src/fetchers/createSystemFetchers.test.ts
+++ b/packages/bingo-systems/src/fetchers/createSystemFetchers.test.ts
@@ -1,0 +1,42 @@
+import { Octokit } from "octokit";
+import { describe, expect, it, vi } from "vitest";
+
+import { createSystemFetchers } from "./createSystemFetchers.js";
+
+describe("createSystemFetchers", () => {
+	it("returns an object with only fetch when no auth is provided", () => {
+		const fetchers = createSystemFetchers({});
+
+		expect(fetchers).toEqual({
+			fetch: globalThis.fetch,
+			octokit: undefined,
+		});
+	});
+
+	it("returns an object with fetch and octokit when auth is provided", () => {
+		const fetchers = createSystemFetchers({ auth: "abc123" });
+
+		expect(fetchers).toEqual({
+			fetch: globalThis.fetch,
+			octokit: expect.any(Octokit),
+		});
+	});
+
+	it("returns an object with the custom fetch when fetch is provided", () => {
+		const fetch = vi.fn();
+		const fetchers = createSystemFetchers({ fetch });
+
+		expect(fetchers).toEqual({ fetch });
+	});
+
+	it("returns an object with the custom fetch and octokit when auth and fetch are provided", () => {
+		const auth = "abc123";
+		const fetch = vi.fn();
+		const fetchers = createSystemFetchers({ auth, fetch });
+
+		expect(fetchers).toEqual({
+			fetch,
+			octokit: expect.any(Octokit),
+		});
+	});
+});

--- a/packages/bingo-systems/src/fetchers/createSystemFetchers.ts
+++ b/packages/bingo-systems/src/fetchers/createSystemFetchers.ts
@@ -13,9 +13,11 @@ export function createSystemFetchers({
 }: SystemFetchersSettings): SystemFetchers {
 	return {
 		fetch,
-		octokit: new Octokit({
-			auth,
-			request: { fetch },
-		}),
+		octokit: auth
+			? new Octokit({
+					auth,
+					request: { fetch },
+				})
+			: undefined,
 	};
 }

--- a/packages/bingo-systems/src/fetchers/types.ts
+++ b/packages/bingo-systems/src/fetchers/types.ts
@@ -11,8 +11,8 @@ export interface SystemFetchers {
 	fetch: typeof fetch;
 
 	/**
-	 * Octokit.js instance wrapping the same `fetch` function.
+	 * Octokit.js instance wrapping the same `fetch` function, if authenticated.
 	 * @see {@link https://octokit.github.io/rest.js}
 	 */
-	octokit: Octokit;
+	octokit: Octokit | undefined;
 }

--- a/packages/bingo/src/cli/setup/createRepositoryOnGitHub.ts
+++ b/packages/bingo/src/cli/setup/createRepositoryOnGitHub.ts
@@ -63,7 +63,7 @@ export async function createRepositoryOnGitHub<
 		(await promptForOptionSchema(
 			"owner",
 			template.options.owner,
-			"GitHub organization or user the repository is underneath",
+			"organization or username owning the repository",
 			undefined,
 		));
 

--- a/packages/bingo/src/cli/setup/runModeSetup.ts
+++ b/packages/bingo/src/cli/setup/runModeSetup.ts
@@ -112,15 +112,16 @@ export async function runModeSetup<OptionsShape extends AnyShape, Refinements>({
 		return { status: CLIStatus.Cancelled };
 	}
 
-	const remote = offline
-		? undefined
-		: await createRepositoryOnGitHub(
-				display,
-				{ repository, ...baseOptions.completed },
-				system.fetchers.octokit,
-				system.runner,
-				template,
-			);
+	const remote =
+		offline || !system.fetchers.octokit
+			? undefined
+			: await createRepositoryOnGitHub(
+					display,
+					{ repository, ...baseOptions.completed },
+					system.fetchers.octokit,
+					system.runner,
+					template,
+				);
 
 	if (remote instanceof Error) {
 		logRerunSuggestion(argv, baseOptions.prompted);

--- a/packages/bingo/src/runners/applyRequestsToSystem.test.ts
+++ b/packages/bingo/src/runners/applyRequestsToSystem.test.ts
@@ -29,6 +29,24 @@ function createStubSystem() {
 }
 
 describe("applyRequestsToSystem", () => {
+	it("does not do anything when getRequestSender returns undefined", async () => {
+		mockGetRequestSender.mockReturnValueOnce(undefined);
+
+		const act = async () => {
+			await applyRequestsToSystem(
+				[
+					{
+						type: "fetch",
+						url: "https://example.com",
+					},
+				],
+				createStubSystem(),
+			);
+		};
+
+		await expect(act()).resolves.toBeUndefined();
+	});
+
 	it("does not display an error when a request  does not reject", async () => {
 		const id = "abc";
 		const send = vi.fn();

--- a/packages/bingo/src/runners/applyRequestsToSystem.ts
+++ b/packages/bingo/src/runners/applyRequestsToSystem.ts
@@ -9,12 +9,17 @@ export async function applyRequestsToSystem(
 ) {
 	await Promise.all(
 		requests.map(async (request) => {
-			const { id, send } = getRequestSender(request);
+			const sender = getRequestSender(system.fetchers, request);
+			if (!sender) {
+				return;
+			}
+
+			const { id, send } = sender;
 
 			system.display.item("request", id, { start: Date.now() });
 
 			try {
-				await send(system.fetchers);
+				await send();
 			} catch (error) {
 				system.display.item("request", id, { error });
 			}

--- a/packages/bingo/src/runners/getRequestSender.test.ts
+++ b/packages/bingo/src/runners/getRequestSender.test.ts
@@ -21,7 +21,10 @@ describe("getRequestSender", () => {
 			url: "https://create.bingo",
 		};
 
-		const actual = getRequestSender(request);
+		const actual = getRequestSender(
+			createMockSystemFetchers() as unknown as SystemFetchers,
+			request,
+		);
 
 		expect(actual).toEqual({
 			id: request.url,
@@ -36,7 +39,10 @@ describe("getRequestSender", () => {
 			url: "https://create.bingo",
 		};
 
-		const actual = getRequestSender(request);
+		const actual = getRequestSender(
+			createMockSystemFetchers() as unknown as SystemFetchers,
+			request,
+		);
 
 		expect(actual).toEqual({
 			id: request.id,
@@ -44,7 +50,7 @@ describe("getRequestSender", () => {
 		});
 	});
 
-	it("sends a request with fetchers.request sending a fetch request", async () => {
+	it("sends a request with fetchers.request when sending a fetch request", async () => {
 		const fetchers = createMockSystemFetchers();
 
 		const request: CreatedFetchRequest = {
@@ -53,10 +59,29 @@ describe("getRequestSender", () => {
 			url: "https://create.bingo",
 		};
 
-		await getRequestSender(request).send(fetchers as unknown as SystemFetchers);
+		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+		await getRequestSender(
+			fetchers as unknown as SystemFetchers,
+			request,
+		)!.send();
 
 		expect(fetchers.fetch).toHaveBeenCalledWith(request.url, request.init);
 		expect(fetchers.octokit.request).not.toHaveBeenCalled();
+	});
+
+	it("returns undefined when given an Octokit request and fetchers.octokit is defined", async () => {
+		const request: CreatedOctokitRequest = {
+			endpoint: "POST /repos/{owner}/{repo}/labels",
+			parameters: { name: "...", owner, repo },
+			type: "octokit",
+		};
+
+		const actual = getRequestSender(
+			{ fetch: vi.fn(), octokit: undefined } as SystemFetchers,
+			request,
+		);
+
+		expect(actual).toBeUndefined();
 	});
 
 	it("returns a sender with url for id when given an Octokit request without id", () => {
@@ -66,7 +91,10 @@ describe("getRequestSender", () => {
 			type: "octokit",
 		};
 
-		const actual = getRequestSender(request);
+		const actual = getRequestSender(
+			createMockSystemFetchers() as unknown as SystemFetchers,
+			request,
+		);
 
 		expect(actual).toEqual({
 			id: request.endpoint,
@@ -82,7 +110,10 @@ describe("getRequestSender", () => {
 			type: "octokit",
 		};
 
-		const actual = getRequestSender(request);
+		const actual = getRequestSender(
+			createMockSystemFetchers() as unknown as SystemFetchers,
+			request,
+		);
 
 		expect(actual).toEqual({
 			id: request.id,
@@ -90,7 +121,7 @@ describe("getRequestSender", () => {
 		});
 	});
 
-	it("sends a request with fetchers.octokit.request sending an Octokit request", async () => {
+	it("sends a request with the Octokit when sending an Octokit request and fetchers.octokit is defined", async () => {
 		const fetchers = createMockSystemFetchers();
 
 		const request: CreatedOctokitRequest = {
@@ -99,7 +130,11 @@ describe("getRequestSender", () => {
 			type: "octokit",
 		};
 
-		await getRequestSender(request).send(fetchers as unknown as SystemFetchers);
+		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+		await getRequestSender(
+			fetchers as unknown as SystemFetchers,
+			request,
+		)!.send();
 
 		expect(fetchers.fetch).not.toHaveBeenCalled();
 		expect(fetchers.octokit.request).toHaveBeenCalledWith(

--- a/packages/bingo/src/runners/getRequestSender.test.ts
+++ b/packages/bingo/src/runners/getRequestSender.test.ts
@@ -69,7 +69,7 @@ describe("getRequestSender", () => {
 		expect(fetchers.octokit.request).not.toHaveBeenCalled();
 	});
 
-	it("returns undefined when given an Octokit request and fetchers.octokit is defined", async () => {
+	it("returns undefined when given an Octokit request and fetchers.octokit is defined", () => {
 		const request: CreatedOctokitRequest = {
 			endpoint: "POST /repos/{owner}/{repo}/labels",
 			parameters: { name: "...", owner, repo },

--- a/packages/bingo/src/runners/getRequestSender.ts
+++ b/packages/bingo/src/runners/getRequestSender.ts
@@ -3,30 +3,37 @@ import { SystemFetchers } from "bingo-systems";
 
 export interface RequestSender {
 	id: string;
-	send: (fetchers: SystemFetchers) => Promise<void>;
+	send: () => Promise<void>;
 }
 
-export function getRequestSender(request: CreatedRequest): RequestSender {
+export function getRequestSender(
+	fetchers: SystemFetchers,
+	request: CreatedRequest,
+): RequestSender | undefined {
 	switch (request.type) {
 		case "fetch":
 			return {
 				id: request.id ?? request.url,
-				send: async (fetchers: SystemFetchers) => {
+				send: async () => {
 					await fetchers.fetch(request.url, request.init);
 				},
 			};
 
-		case "octokit":
-			return {
-				id: request.id ?? request.endpoint,
-				send: async (fetchers: SystemFetchers) => {
-					await fetchers.octokit.request(
-						request.endpoint,
-						// TODO: I have no idea how to get this to type-check without the any.
-						// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
-						request.parameters as any,
-					);
-				},
-			};
+		case "octokit": {
+			const { octokit } = fetchers;
+			return (
+				octokit && {
+					id: request.id ?? request.endpoint,
+					send: async () => {
+						await octokit.request(
+							request.endpoint,
+							// TODO: I have no idea how to get this to type-check without the any.
+							// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
+							request.parameters as any,
+						);
+					},
+				}
+			);
+		}
 	}
 }

--- a/packages/site/src/content/docs/build/apis/run-creation.mdx
+++ b/packages/site/src/content/docs/build/apis/run-creation.mdx
@@ -66,15 +66,22 @@ await runCration(
 
 File, network, and shell wrapper APIs.
 
-By default, these are provided by [`bingo-systems`](/build/packages/bingo-systems).
+`system` may contain the following properties, which have the following defaults:
+
+- `fetchers`: [`createSystemFetchers`](/build/packages/bingo-systems#fetchers)
+- `fs`: [`createWritingFileSystem`](/build/packages/bingo-systems#files)
+- `runner`: [`createSystemRunner`](/build/packages/bingo-systems#runner)
+- `take`: a function that passes those properties to the Input
+
 They can be swapped out if you want to change or otherwise intercept system calls.
 
 For example, this adds a log to every shell command:
 
 ```ts
-import { createSystemContext } from "bingo-systems";
+import { runCreation } from "bingo";
+import { createSystemRunner } from "bingo-systems";
 
-const defaultSystem = createSystemContext();
+const defaultRunner = createSystemRunner();
 
 await runCreation(
 	{
@@ -82,10 +89,9 @@ await runCreation(
 	},
 	{
 		system: {
-			...createSystemContext(),
 			runner: async (...args) => {
 				console.log("Running:", args);
-				return await defaultSystem.runner(args);
+				return await defaultRunner(args);
 			},
 		},
 	},

--- a/packages/site/src/content/docs/build/packages/bingo-systems.mdx
+++ b/packages/site/src/content/docs/build/packages/bingo-systems.mdx
@@ -41,12 +41,12 @@ import { Octokit } from "octokit";
 
 export interface SystemFetchers {
 	fetch: typeof fetch;
-	octokit: Octokit;
+	octokit: Octokit | undefined;
 }
 ```
 
-The `octokit` property is also available as a convenience for sending GitHub API requests.
-This is typically used to populate repository settings via the API.
+The `octokit` property is optionally available for sending GitHub API requests.
+This is typically used to populate repository settings via GitHub's API.
 
 ### `createSystemFetchers`
 
@@ -62,7 +62,7 @@ await fetchers.fetch("...");
 
 Takes in an optional object parameter with up to two properties:
 
-- `auth` (`string`): a GitHub auth token to pass to the `octokit`
+- `auth` (`string`): a GitHub auth token create the [`octokit`](#octokit) property with
 - `fetch`: a function to use in place of the global [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API)
   - This is used both for the `fetch` property and in the `octokit`
 

--- a/packages/site/src/content/docs/build/packages/bingo-systems.mdx
+++ b/packages/site/src/content/docs/build/packages/bingo-systems.mdx
@@ -62,7 +62,7 @@ await fetchers.fetch("...");
 
 Takes in an optional object parameter with up to two properties:
 
-- `auth` (`string`): a GitHub auth token create the [`octokit`](#octokit) property with
+- `auth` (`string`): a GitHub auth token create the `octokit` property with
 - `fetch`: a function to use in place of the global [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API)
   - This is used both for the `fetch` property and in the `octokit`
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #275
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/bingo/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/bingo/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Changes `createSystemFetchers` & `SystemFetchers` to make `auth` -> `octokit` optional. `octokit` will only be created if auth is available. As a result, downstream:

* The Bingo CLI will then only attempt to create a repository if `!offline` and that `octokit` was able to create a repository
* `applyRequestsToSystem` won't attempt to make requests when an equivalent "sender" cannot be created: which is the case for `type: "octokit"` requests and no `octokit`

💝 