### PR TITLE
fix(bingo): correct Windows paths handling

### DIFF
--- a/packages/bingo/src/cli/getTemplatePackageData.test.ts
+++ b/packages/bingo/src/cli/getTemplatePackageData.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { getTemplatePackageData } from "./getTemplatePackageData.js";
+import { resolveFilePath } from "./utils.js";
 
 const mockGetCallId = vi.fn();
 
@@ -18,6 +19,32 @@ vi.mock("read-package-up", () => ({
 	},
 }));
 
+let isWindows = false;
+
+vi.mock("node:url", async () => {
+	const nodeUrl = await vi.importActual<typeof import("node:url")>("node:url");
+	return {
+		...nodeUrl,
+		fileURLToPath: (url: string | URL) =>
+			nodeUrl.fileURLToPath(url, { windows: isWindows }),
+	};
+});
+
+vi.mock("./utils.ts", { spy: true });
+
+const testPaths = {
+	posix: {
+		input: "/home/user/project/file.js",
+		output: "/home/user/project/file.js",
+		outputDir: "/home/user/project",
+	},
+	windows: {
+		input: "/C:/Users/User/file.js",
+		output: "C:\\Users\\User\\file.js",
+		outputDir: "C:\\Users\\User",
+	},
+};
+
 describe("getTemplatePackageData", () => {
 	it("returns an error when getCallId returns undefined", async () => {
 		mockGetCallId.mockReturnValueOnce(undefined);
@@ -31,39 +58,66 @@ describe("getTemplatePackageData", () => {
 		);
 	});
 
-	describe("getTemplatePackageData", () => {
-		it("returns an error when getCallId returns undefined", async () => {
-			mockGetCallId.mockReturnValueOnce(undefined);
+	it("returns an error when readPackageUp returns undefined on POSIX", async () => {
+		isWindows = false;
 
-			const actual = await getTemplatePackageData();
+		mockGetCallId.mockReturnValueOnce({ file: testPaths.posix.input });
+		mockReadPackageUp.mockResolvedValueOnce(undefined);
 
-			expect(actual).toEqual(
-				new Error(
-					"Could not determine what directory this Bingo CLI is being called from.",
-				),
-			);
-		});
+		const actual = await getTemplatePackageData();
 
-		it("returns an error when readPackageUp returns undefined", async () => {
-			mockGetCallId.mockReturnValueOnce({ file: "/path/to/file.js" });
-			mockReadPackageUp.mockResolvedValueOnce(undefined);
+		expect(actual).toEqual(
+			new Error(
+				`Could not find a package.json relative to '${testPaths.posix.outputDir}'.`,
+			),
+		);
+		expect(resolveFilePath).toHaveBeenCalledWith(testPaths.posix.input);
+		expect(resolveFilePath).toHaveReturnedWith(testPaths.posix.output);
+	});
 
-			const actual = await getTemplatePackageData();
+	it("returns an error when readPackageUp returns undefined on Windows", async () => {
+		isWindows = true;
 
-			expect(actual).toEqual(
-				new Error("Could not find a package.json relative to '/path/to'."),
-			);
-		});
+		mockGetCallId.mockReturnValueOnce({ file: testPaths.windows.input });
+		mockReadPackageUp.mockResolvedValueOnce(undefined);
 
-		it("returns packageJson when readPackageUp finds a package.json", async () => {
-			const mockPackageJson = { name: "test-package" };
-			mockGetCallId.mockReturnValueOnce({ file: "/path/to/file.js" });
-			mockReadPackageUp.mockResolvedValueOnce({ packageJson: mockPackageJson });
+		const actual = await getTemplatePackageData();
 
-			const actual = await getTemplatePackageData();
+		expect(actual).toEqual(
+			new Error(
+				`Could not find a package.json relative to '${testPaths.windows.outputDir}'.`,
+			),
+		);
+		expect(resolveFilePath).toHaveBeenCalledWith(testPaths.windows.input);
+		expect(resolveFilePath).toHaveReturnedWith(testPaths.windows.output);
+	});
 
-			expect(actual).toBe(mockPackageJson);
-		});
+	it("returns packageJson when readPackageUp finds a package.json on POSIX", async () => {
+		isWindows = false;
+
+		const mockPackageJson = { name: "test-package" };
+		mockGetCallId.mockReturnValueOnce({ file: testPaths.posix.input });
+		mockReadPackageUp.mockResolvedValueOnce({ packageJson: mockPackageJson });
+
+		const actual = await getTemplatePackageData();
+
+		expect(actual).toBe(mockPackageJson);
+		expect(resolveFilePath).toHaveBeenCalledWith(testPaths.posix.input);
+		expect(resolveFilePath).toHaveReturnedWith(testPaths.posix.output);
+	});
+
+	it("returns packageJson when readPackageUp finds a package.json on Windows", async () => {
+		isWindows = true;
+
+		const mockPackageJson = { name: "test-package" };
+		mockGetCallId.mockReturnValueOnce({ file: testPaths.windows.input });
+		mockReadPackageUp.mockResolvedValueOnce({ packageJson: mockPackageJson });
+
+		const actual = await getTemplatePackageData();
+
+		expect(actual).toBe(mockPackageJson);
+		expect(resolveFilePath).toHaveBeenCalledWith(testPaths.windows.input);
+		expect(resolveFilePath).toHaveReturnedWith(testPaths.windows.output);
 	});
 });
 

--- a/packages/bingo/src/cli/getTemplatePackageData.test.ts
+++ b/packages/bingo/src/cli/getTemplatePackageData.test.ts
@@ -30,15 +30,13 @@ vi.mock("node:url", async () => {
 });
 
 vi.mock("node:path", async () => {
-	const nodePath =
-		await vi.importActual<typeof import("node:path")>("node:path");
 	const nodePathWindows =
 		await vi.importActual<typeof import("node:path/win32")>("node:path/win32");
 	const nodePathPosix =
 		await vi.importActual<typeof import("node:path/posix")>("node:path/posix");
 	return {
 		default: {
-			...nodePath,
+			...(await vi.importActual("node:path")),
 			dirname: (path: string) =>
 				isWindowsPaths
 					? nodePathWindows.dirname(path)

--- a/packages/bingo/src/cli/getTemplatePackageData.ts
+++ b/packages/bingo/src/cli/getTemplatePackageData.ts
@@ -2,6 +2,8 @@ import { getCallId } from "call-id";
 import path from "path";
 import { readPackageUp } from "read-package-up";
 
+import { resolveFilePath } from "./utils.js";
+
 export async function getTemplatePackageData() {
 	const callId = getCallId(2);
 
@@ -11,7 +13,7 @@ export async function getTemplatePackageData() {
 		);
 	}
 
-	const directory = path.dirname(callId.file);
+	const directory = path.dirname(resolveFilePath(callId.file));
 	const result = await readPackageUp({ cwd: directory });
 
 	return (

--- a/packages/bingo/src/cli/getTemplatePackageData.ts
+++ b/packages/bingo/src/cli/getTemplatePackageData.ts
@@ -1,8 +1,7 @@
 import { getCallId } from "call-id";
-import path from "path";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { readPackageUp } from "read-package-up";
-
-import { resolveFilePath } from "./utils.js";
 
 export async function getTemplatePackageData() {
 	const callId = getCallId(2);
@@ -13,11 +12,13 @@ export async function getTemplatePackageData() {
 		);
 	}
 
-	const directory = path.dirname(resolveFilePath(callId.file));
-	const result = await readPackageUp({ cwd: directory });
+	const directoryUrl = new URL(path.dirname(callId.file), "file://");
+	const result = await readPackageUp({ cwd: directoryUrl });
 
 	return (
 		result?.packageJson ??
-		new Error(`Could not find a package.json relative to '${directory}'.`)
+		new Error(
+			`Could not find a package.json relative to '${fileURLToPath(directoryUrl)}'.`,
+		)
 	);
 }

--- a/packages/bingo/src/cli/utils.ts
+++ b/packages/bingo/src/cli/utils.ts
@@ -5,9 +5,5 @@ export function makeRelative(item: string) {
 }
 
 export function resolveFilePath(filePath: string) {
-	const fileUrl = filePath.startsWith("file://")
-		? new URL(filePath)
-		: new URL(filePath, "file://");
-
-	return fileURLToPath(fileUrl);
+	return fileURLToPath(new URL(filePath, "file://"));
 }

--- a/packages/bingo/src/cli/utils.ts
+++ b/packages/bingo/src/cli/utils.ts
@@ -1,3 +1,13 @@
+import { fileURLToPath } from "node:url";
+
 export function makeRelative(item: string) {
 	return item.startsWith(".") ? item : `./${item}`;
+}
+
+export function resolveFilePath(filePath: string) {
+	const fileUrl = filePath.startsWith("file://")
+		? new URL(filePath)
+		: new URL(filePath, "file://");
+
+	return fileURLToPath(fileUrl);
 }

--- a/packages/bingo/src/cli/utils.ts
+++ b/packages/bingo/src/cli/utils.ts
@@ -1,9 +1,3 @@
-import { fileURLToPath } from "node:url";
-
 export function makeRelative(item: string) {
 	return item.startsWith(".") ? item : `./${item}`;
-}
-
-export function resolveFilePath(filePath: string) {
-	return fileURLToPath(new URL(filePath, "file://"));
 }

--- a/packages/bingo/src/runners/runInput.test.ts
+++ b/packages/bingo/src/runners/runInput.test.ts
@@ -11,7 +11,10 @@ const input = createInput({
 	},
 	async produce({ args, runner }) {
 		return {
-			directory: (await runner("pwd")).stdout,
+			directory:
+				process.platform === "win32"
+					? (await runner("cd")).stdout
+					: (await runner("pwd")).stdout,
 			doubled: args.value * 2,
 		};
 	},


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to Bingo! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #300
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/bingo/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/bingo/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

### :monocle_face: The problem

On Windows, file URLs in the `Node.js` environment often include an extra slash after the `file://` protocol, resulting in URLs like `file:///C:/Users/User/file.js`. When parsed using `.pathname`, the output includes a leading slash before the drive letter, yielding `/C:/Users/User/file.js`. While this leading slash complies with the URL specification to denote an absolute path, Windows uses drive letters instead of a root directory. Consequently, this results in an invalid file path since Windows paths should begin directly with the drive letter, such as `C:/Users/User/file.js`. Moreover, mishandling paths with a leading slash can lead to misinterpretation. For example, paths like `/C:/Users/User/file.js` may be treated as relative to the current drive, potentially producing an erroneous path with duplicated drive letters like `C:/C:/Users/User/file.js`. As for the use of forward and backward slashes on Windows, I encountered no issues in this context, since Windows generally accepts both types of slashes.

### :bulb: The solution

I see two possible approaches to solve this problem, each with its advantages.

---

**1. Using a Regular Expressions for Platform-Specific Path Fixing**

This is the approach I used as a base for my PR.
It removes any leading slashes in the absolute file paths on Windows platforms using a simple RegEx:

```ts
function fixPathIfWindows(path: string) {
	return process.platform === "win32"
		? path.replace(/^[/\\]+([A-Z]:[/\\])/i, "$1")
		: path;
}

const directory = fixPathIfWindows(path.dirname(callId.file));
```

#### Why?
- Lightweight and straightforward.
- Avoids unnecessary module imports.
- Sufficient for resolving the current issue without introducing additional complexity.

---

**2. Using `fileURLToPath` for Cross-Platform Compatibility**

Alternatively, `fileURLToPath` from the `node:url` module can be used to reliably convert a file URL to a native path.
Combined with `new URL(path, 'file://')` for URL construction, this provides robust, cross-platform compatibility:

```ts
import { dirname } from "path";
import { fileURLToPath } from "url";

const directory = dirname(fileURLToPath(new URL(callId.file, 'file://')));
```

#### Why?
- Ensures correct path conversion on all platforms without relying on manual string manipulation.
- Built-in `Node.js` utility specifically designed for handling file URLs safely.

---

Both approaches are valid, but since the first one directly addresses the issue with minimal overhead, I opted for it in my PR.

Looking forward to your review and feedback.
Thanks!