### PR TITLE
feat(bingo-stratum): generate --add-* options alongside --exclude-*

### DIFF
--- a/packages/bingo-stratum/package.json
+++ b/packages/bingo-stratum/package.json
@@ -26,6 +26,7 @@
 	},
 	"dependencies": {
 		"all-properties-lazy": "^0.1.0",
+		"cached-factory": "^0.1.0",
 		"chalk": "^5.4.1",
 		"hash-object": "^5.0.1",
 		"octokit": "^4.1.2",

--- a/packages/bingo-stratum/src/creators/createStratumTemplate.test.ts
+++ b/packages/bingo-stratum/src/creators/createStratumTemplate.test.ts
@@ -59,6 +59,7 @@ describe("createStratumTemplate", () => {
 			expect(Object.keys(template.options)).toEqual([
 				"name",
 				"preset",
+				"add-example-block",
 				"exclude-example-block",
 			]);
 		});

--- a/packages/bingo-stratum/src/producers/applyBlockRefinements.ts
+++ b/packages/bingo-stratum/src/producers/applyBlockRefinements.ts
@@ -1,29 +1,76 @@
+import { CachedFactory } from "cached-factory";
+
 import { Block } from "../types/blocks.js";
 import { BlockRefinements } from "../types/refinements.js";
-import { createBlockExclusionOption } from "../utils/createBlockExclusionOption.js";
+
+interface BlockRefinement {
+	add?: boolean;
+	exclude?: boolean;
+}
+
+type BlockWithName = Block & { about: { name: string } };
 
 export function applyBlockRefinements<Options extends object>(
+	blocksAvailable: Block<object | undefined, Options>[],
 	blocksInitial: Block<object | undefined, Options>[],
 	options: Options,
 	{ add = [], exclude = [] }: BlockRefinements<Options> = {},
 ) {
-	const exclusionOptions = new Set(
+	const allOptions = new Set(
 		Object.entries(options)
-			.filter(([key, value]) => key.startsWith("exclude-") && !!value)
+			.filter(([, value]) => !!value)
 			.map(([key]) => key),
 	);
+	const allBlocksByName = new Map(
+		blocksAvailable
+			.filter((block): block is BlockWithName => !!block.about?.name)
+			.map((block) => [block.about.name.toLowerCase(), block]),
+	);
+	const refinementsByBlock = new CachedFactory<string, BlockRefinement>(
+		() => ({}),
+	);
+	let hadBlockRefinement = false;
 
-	if (!add.length && !exclude.length && !exclusionOptions.size) {
+	for (const optionKey of allOptions) {
+		const matches = /^(add|exclude)-(.+)/.exec(optionKey.toLowerCase());
+		if (!matches) {
+			continue;
+		}
+
+		const [, action, blockName] = matches;
+		if (!allBlocksByName.has(blockName)) {
+			throw new Error(`Unknown Block refinement option: --${optionKey}`);
+		}
+
+		const refinements = refinementsByBlock.get(blockName);
+
+		refinements[action as "add" | "exclude"] = true;
+
+		if (refinements.add && refinements.exclude) {
+			throw new Error(
+				`Cannot both add and exclude the same block: --add-${blockName}, --exclude-${blockName}`,
+			);
+		}
+
+		hadBlockRefinement = true;
+	}
+
+	if (!add.length && !exclude.length && !hadBlockRefinement) {
 		return blocksInitial;
 	}
 
-	const blocksRefined = new Set(
-		blocksInitial.filter(
-			(block) =>
-				block.about?.name &&
-				!exclusionOptions.has(createBlockExclusionOption(block.about.name)),
-		),
-	);
+	const blocksRefined = new Set(blocksInitial);
+
+	for (const [blockName, blockRefinements] of refinementsByBlock.entries()) {
+		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+		const block = allBlocksByName.get(blockName)!;
+
+		if (blockRefinements.add) {
+			blocksRefined.add(block);
+		} else {
+			blocksRefined.delete(block);
+		}
+	}
 
 	for (const added of add) {
 		blocksRefined.add(added);

--- a/packages/bingo-stratum/src/producers/producePreset.test.ts
+++ b/packages/bingo-stratum/src/producers/producePreset.test.ts
@@ -98,4 +98,61 @@ describe("producePreset", () => {
 			},
 		});
 	});
+
+	it("uses the template's blocks for refinement if a template is provided", () => {
+		const baseWithoutOption = createBase({
+			options: {},
+		});
+
+		const blockA = baseWithoutOption.createBlock({
+			about: { name: "A" },
+			produce() {
+				return {
+					files: {
+						"a.txt": "a",
+					},
+				};
+			},
+		});
+
+		const blockB = baseWithoutOption.createBlock({
+			about: { name: "B" },
+			produce() {
+				return {
+					files: {
+						"b.txt": "b",
+					},
+				};
+			},
+		});
+
+		const presetA = baseWithoutOption.createPreset({
+			about: { name: "A" },
+			blocks: [blockA],
+		});
+		const presetAB = baseWithoutOption.createPreset({
+			about: { name: "AB" },
+			blocks: [blockA, blockB],
+		});
+
+		const template = baseWithoutOption.createStratumTemplate({
+			presets: [presetA, presetAB],
+		});
+
+		const actual = producePreset(presetA, {
+			...system,
+			options: {
+				"add-b": true,
+			},
+			template,
+		});
+
+		expect(actual).toEqual({
+			...emptyCreation,
+			files: {
+				"a.txt": "a",
+				"b.txt": "b",
+			},
+		});
+	});
 });

--- a/packages/bingo-stratum/src/producers/producePreset.ts
+++ b/packages/bingo-stratum/src/producers/producePreset.ts
@@ -3,6 +3,7 @@ import { AnyShape, InferredObject, ProduceTemplateSettings } from "bingo";
 import { BlockCreation } from "../types/creations.js";
 import { Preset } from "../types/presets.js";
 import { StratumRefinements } from "../types/refinements.js";
+import { StratumTemplate } from "../types/templates.js";
 import { applyBlockRefinements } from "./applyBlockRefinements.js";
 import { produceBlocks } from "./produceBlocks.js";
 
@@ -21,6 +22,11 @@ export interface ProducePresetSettings<OptionsShape extends AnyShape>
 	 * @see {@link https://create.bingo/engines/stratum/details/configurations#refinements}
 	 */
 	refinements?: StratumRefinements<InferredObject<OptionsShape>>;
+
+	/**
+	 * Parent Template, if more Blocks may be needed.
+	 */
+	template?: StratumTemplate<OptionsShape>;
 }
 
 /**
@@ -35,9 +41,11 @@ export function producePreset<OptionsShape extends AnyShape>(
 		offline,
 		options,
 		refinements = {},
+		template,
 	}: ProducePresetSettings<OptionsShape>,
 ): BlockCreation<InferredObject<OptionsShape>> {
 	const blocks = applyBlockRefinements(
+		template?.blocks ?? preset.blocks,
 		preset.blocks,
 		options,
 		refinements.blocks,

--- a/packages/bingo-stratum/src/producers/produceStratumTemplate.ts
+++ b/packages/bingo-stratum/src/producers/produceStratumTemplate.ts
@@ -30,6 +30,7 @@ export function produceStratumTemplate<
 	}
 
 	const blocks = applyBlockRefinements(
+		template.blocks,
 		preset.blocks,
 		options,
 		refinements.blocks,

--- a/packages/bingo-stratum/src/types/templates.ts
+++ b/packages/bingo-stratum/src/types/templates.ts
@@ -8,6 +8,7 @@ import {
 import { z } from "zod";
 
 import { Base } from "./bases.js";
+import { Block } from "./blocks.js";
 import { Preset } from "./presets.js";
 import { StratumRefinements } from "./refinements.js";
 
@@ -26,6 +27,11 @@ export interface StratumTemplate<OptionsShape extends AnyShape>
 	 * @see {@link https://www.create.bingo/engines/stratum/concepts/bases}
 	 */
 	base: Base<OptionsShape>;
+
+	/**
+	 * All the Blocks available in any of the Template's Presets.
+	 */
+	blocks: Block<object | undefined, InferredObject<OptionsShape>>[];
 
 	/**
 	 * Sets up lazily load default options values.

--- a/packages/bingo-stratum/src/utils/createBlockExclusionOption.ts
+++ b/packages/bingo-stratum/src/utils/createBlockExclusionOption.ts
@@ -1,5 +1,0 @@
-import { slugifyName } from "./slugifyName.js";
-
-export function createBlockExclusionOption(blockName: string) {
-	return `exclude-${slugifyName(blockName)}`;
-}

--- a/packages/bingo-stratum/src/utils/createBlockRefinementOption.ts
+++ b/packages/bingo-stratum/src/utils/createBlockRefinementOption.ts
@@ -1,0 +1,5 @@
+import { slugifyName } from "./slugifyName.js";
+
+export function createBlockRefinementOption(prefix: string, blockName: string) {
+	return `${prefix}-${slugifyName(blockName)}`;
+}

--- a/packages/site/src/content/docs/engines/stratum/apis/producers.mdx
+++ b/packages/site/src/content/docs/engines/stratum/apis/producers.mdx
@@ -309,3 +309,26 @@ producePreset(preset, {
 ```
 
 See [Configurations > `blocks`](/engines/stratum/details/configurations#blocks) for how this is used.
+
+### `template` {#preset-template}
+
+Parent Template that contains the Preset.
+This is used to resolve any [Block Refinements](/engines/stratum/concepts/templates#refinement-options) that add blocks.
+
+For example, this production runs a Preset that includes an "Extra Fun" Block from its parent Template:
+
+```ts
+import { Preset, producePreset } from "bingo";
+import { z } from "zod";
+
+declare const preset: Preset;
+declare const template: Template;
+
+producePreset(preset, {
+	options: {
+		"add-extra-fun": true,
+		name: "My Production",
+	},
+	preset: "example",
+});
+```

--- a/packages/site/src/content/docs/engines/stratum/apis/runners.mdx
+++ b/packages/site/src/content/docs/engines/stratum/apis/runners.mdx
@@ -337,3 +337,26 @@ await runPreset(preset, {
 ```
 
 See [Configurations > `blocks`](/engines/stratum/details/configurations#blocks) for how this is used.
+
+### `template` {#preset-template}
+
+Parent Template that contains the Preset.
+This is used to resolve any [Block Refinements](/engines/stratum/concepts/templates#refinement-options) that add blocks.
+
+For example, this production runs a Preset that includes an "Extra Fun" Block from its parent Template:
+
+```ts
+import { Preset, producePreset } from "bingo";
+import { z } from "zod";
+
+declare const preset: Preset;
+declare const template: Template;
+
+producePreset(preset, {
+	options: {
+		"add-extra-fun": true,
+		name: "My Production",
+	},
+	preset: "example",
+});
+```

--- a/packages/site/src/content/docs/engines/stratum/concepts/templates.mdx
+++ b/packages/site/src/content/docs/engines/stratum/concepts/templates.mdx
@@ -79,9 +79,9 @@ During transition mode, Stratum will attempt to infer a default value for `--pre
 That default value is computed by comparing existing files on disk to the files that would be produced by the Blocks.
 If Preset with the greatest percentage matches 35% or more of its created files, it will be used as the default.
 
-### Exclusion Options
+### Refinement Options
 
-Stratum Templates also add `--exclude-*` CLI options for each of their named Blocks.
+Stratum Templates also generate `--add-*` and `--exclude-*` CLI options for each of their named Blocks.
 Each Block name is transformed to kebab-cases boolean option that defaults to `false`.
 
 For example, given the following named `ESLint` Block:
@@ -103,13 +103,16 @@ export const blockESLint = base.createBlock({
 });
 ```
 
-If a Stratum Template includes that Block, it will have an `--exclude-eslint` option available on the CLI:
+If a Stratum Template includes that Block, it will generate two options available on the CLI:
+
+- `--add-eslint`: to add the Block if not already present in the selected Preset
+- `--exclude-eslint`: to exclude the Block if already present in the selected Preset
 
 ```shell
 npx create-stratum-example --exclude-eslint
 ```
 
 :::note
-Exclusion options are not added to the TypeScript types of `createConfig` functions in configuration files.
-See [Details > Configurations > Refinements > `exclude`](/engines/stratum/details/configurations#exclude) for excluding Blocks in configuration files.
+Refinement options are not added to the TypeScript types of `createConfig` functions in configuration files.
+See [Details > Configurations > Refinements](/engines/stratum/details/configurations#refinements) for modifying Blocks with configuration files.
 :::

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -213,6 +213,9 @@ importers:
       bingo-systems:
         specifier: workspace:^
         version: link:../bingo-systems
+      cached-factory:
+        specifier: ^0.1.0
+        version: 0.1.0
       chalk:
         specifier: ^5.4.1
         version: 5.4.1


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #257
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/bingo/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [ ] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/bingo/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Additionally generates `--add-*` options for each Block in Stratum templates, not just `--exclude-*`. This requires knowing the parent Template so I added:

* `blocks` as a property of `StratumTemplate`, based on all unique blocks from its Presets
* `template` as an option setting for `producePreset` and `runPreset`

🎁 
