### PR TITLE
fix(bingo-stratum): return Addon merging errors for root-level array mismatches

### DIFF
--- a/packages/bingo-stratum/src/mergers/mergeAddonsIfUpdated.test.ts
+++ b/packages/bingo-stratum/src/mergers/mergeAddonsIfUpdated.test.ts
@@ -5,6 +5,11 @@ import { mergeAddonsIfUpdated } from "./mergeAddonsIfUpdated.js";
 describe("mergeArgsIfUpdated", () => {
 	it.each([
 		[{}, {}, undefined],
+		[[], [], undefined],
+		[[], {}, new Error("Mismatched merging addons (Array.isArray).")],
+		[{}, [], new Error("Mismatched merging addons (Array.isArray).")],
+		[["a"], ["a"], undefined],
+		[["a"], ["b"], ["a", "b"]],
 		[{ a: true }, {}, { a: true }],
 		[{ a: true }, { a: null }, undefined],
 		[{ a: true }, { a: true }, undefined],


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #315
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/bingo/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/bingo/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This still doesn't _throw_ the error, so they're not yet appropriately handled outside of mergers. But it's progress.

💝 