### PR TITLE
fix(create): add shebang for executable script

### DIFF
--- a/packages/create/bin/index.js
+++ b/packages/create/bin/index.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import chalk from "chalk";
 
 console.log(


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to Bingo! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #306
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/bingo/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/bingo/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

### :monocle_face: The Problem

Running `npx create <template>` (a mistyped version of the correct `npm create <template>` command) should execute a script that informs the user about the mistake. However, due to the absence of the shebang line (`#!/usr/bin/env node`), which specifies the interpreter, in the `index.js` file of the `create` package, the script fails to execute, either producing an error or simply opening the `index.js` file in an editor instead of executing it with the interpreter.

### :bulb: The Solution

Adding the shebang line specifying the interpreter (`#!/usr/bin/env node`) to the `index.js` file of the `create` package ensures that the script runs correctly, providing the intended message when `npx create <template>` is used mistakenly.

### :heavy_check_mark: Testing
I have tested this change on Windows and WSL (Ubuntu 24.04.2 LTS), and it works as expected.

## Additional Info

💖
