### PR TITLE
fix: allowed Block intakes to return undefined, with more docs

### DIFF
--- a/packages/bingo-stratum-testers/src/testBlock.ts
+++ b/packages/bingo-stratum-testers/src/testBlock.ts
@@ -18,11 +18,28 @@ export interface BlockContextSettingsWithOptionalAddons<
 }
 
 export interface BlockContextSettingsWithoutAddons<Options extends object> {
+	/**
+	 * Which repository mode Bingo to simulate being run in.
+	 * @see {@link https://create.bingo/build/concepts/modes}
+	 */
 	mode?: ProductionMode;
+
+	/**
+	 * Whether to simulate being run in an "offline" mode.
+	 * @see {@link http://create.bingo/build/details/contexts#options-offline}
+	 */
 	offline?: boolean;
+
+	/**
+	 * Any options values as described by the Block's Base's options schema, as well as preset.
+	 */
 	options?: Options & StratumTemplateOptions;
 }
 
+/**
+ * Simulates running a Block in-memory for tests.
+ * @see {@link https://www.create.bingo/engines/stratum/packages/bingo-stratum-testers/#testblock}
+ */
 export function testBlock<Addons extends object, Options extends object>(
 	block: BlockWithAddons<Addons, Options>,
 	settings: BlockContextSettingsWithOptionalAddons<Addons, Options>,

--- a/packages/bingo-stratum/src/producers/produceBlock.ts
+++ b/packages/bingo-stratum/src/producers/produceBlock.ts
@@ -40,8 +40,21 @@ export interface ProduceBlockSettingsWithAddons<
  * @see {@link https://www.create.bingo/engines/stratum/apis/producers#produceblock}
  */
 export interface ProduceBlockSettingsWithoutAddons<Options extends object> {
+	/**
+	 * Which repository mode Bingo is being run in.
+	 * @see {@link https://create.bingo/build/concepts/modes}
+	 */
 	mode?: ProductionMode;
+
+	/**
+	 * Whether Bingo is being run in an "offline" mode.
+	 * @see {@link http://create.bingo/build/details/contexts#options-offline}
+	 */
 	offline?: boolean;
+
+	/**
+	 * Options values as described by the Block's Base's options schema.
+	 */
 	options: Options;
 }
 

--- a/packages/bingo-stratum/src/producers/produceBlocks.ts
+++ b/packages/bingo-stratum/src/producers/produceBlocks.ts
@@ -39,10 +39,11 @@ export function produceBlocks<Options extends object>(
 
 	// 1.1. Run any intake methods to generate default Addons values
 	for (const block of blocks) {
-		if (isBlockWithAddons(block) && block.intake) {
-			blockProductions.set(block, {
-				addons: block.intake({ files }),
-			});
+		if (isBlockWithAddons(block)) {
+			const addons = block.intake?.({ files });
+			if (addons) {
+				blockProductions.set(block, { addons });
+			}
 		}
 	}
 	// 2.2. Apply all provided refinements on top of those

--- a/packages/bingo-stratum/src/types/blocks.ts
+++ b/packages/bingo-stratum/src/types/blocks.ts
@@ -199,7 +199,7 @@ export interface BlockDefinitionWithoutAddons<Options extends object>
  */
 export type BlockIntake<Addons extends object> = (
 	context: BlockIntakeContext,
-) => Partial<Addons>;
+) => Partial<Addons> | undefined;
 
 /**
  * Generates the creations describing a portion of a repository with addons.

--- a/packages/site/src/content/docs/engines/stratum/packages/bingo-stratum-testers.mdx
+++ b/packages/site/src/content/docs/engines/stratum/packages/bingo-stratum-testers.mdx
@@ -44,8 +44,8 @@ import { describe, expect, it } from "vitest";
 import { blockNvmrc } from "./blockNvmrc";
 
 describe("blockNvmrc", () => {
-	it("returns an .nvmrc", async () => {
-		const actual = await testBlock(blockNvmrc);
+	it("returns an .nvmrc", () => {
+		const actual = testBlock(blockNvmrc);
 
 		expect(actual).toEqual({
 			files: { ".nvmrc": "20.12.2" },
@@ -92,8 +92,8 @@ const blockPrettier = base.createBlock({
 });
 
 describe("blockPrettier", () => {
-	it("creates a .prettierrc.json when provided options", async () => {
-		const actual = await testBlock(blockPrettier, {
+	it("creates a .prettierrc.json when provided options", () => {
+		const actual = testBlock(blockPrettier, {
 			addons: {
 				config: {
 					useTabs: true,
@@ -136,8 +136,8 @@ const blockReadme = base.createBlock({
 });
 
 describe("blockDocs", () => {
-	it("uses options.name for the README.md title", async () => {
-		const actual = await testBlock(blockReadme, {
+	it("uses options.name for the README.md title", () => {
+		const actual = testBlock(blockReadme, {
 			options: {
 				preset: "test",
 				title: "My Project",


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #333
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/bingo/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/bingo/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Allows `intake` to return `undefined`. Also adds in docs without any runtime behavior changes.

💝 