### PR TITLE
feat: intake files in transition mode CLI and pass to templates

### DIFF
--- a/packages/bingo-fs/src/intake.ts
+++ b/packages/bingo-fs/src/intake.ts
@@ -33,15 +33,15 @@ export async function intake(rootPath: string, settings: IntakeSettings = {}) {
 		: await intakeFile(rootPath, stats.mode);
 }
 
-async function intakeDirectory(
+export async function intakeDirectory(
 	directoryPath: string,
-	settings: IntakeSettings,
+	settings?: IntakeSettings,
 ): Promise<IntakeDirectory> {
 	const directory: IntakeDirectory = {};
 	const children = await fs.readdir(directoryPath);
 
 	for (const child of children) {
-		if (!settings.exclude?.test(child)) {
+		if (!settings?.exclude?.test(child)) {
 			directory[child] = await intake(
 				path.join(directoryPath, child),
 				settings,

--- a/packages/bingo-stratum/src/producers/produceStratumTemplate.ts
+++ b/packages/bingo-stratum/src/producers/produceStratumTemplate.ts
@@ -8,6 +8,9 @@ import { applyBlockRefinements } from "./applyBlockRefinements.js";
 import { produceBlocks } from "./produceBlocks.js";
 
 export interface ProduceStratumTemplateSettings<OptionsShape extends AnyShape> {
+	/**
+	 * Existing file creations to be used for Blocks that can intake Addons.
+	 */
 	files?: IntakeDirectory;
 	mode?: ProductionMode;
 	offline?: boolean;

--- a/packages/bingo/src/cli/runTemplateCLI.test.ts
+++ b/packages/bingo/src/cli/runTemplateCLI.test.ts
@@ -22,6 +22,8 @@ vi.mock("@clack/prompts", () => ({
 	}),
 }));
 
+vi.mock("bingo-fs");
+
 vi.mock("../packageData.js", () => ({
 	packageData: {
 		name: "bingo",

--- a/packages/bingo/src/cli/transition/runModeTransition.test.ts
+++ b/packages/bingo/src/cli/transition/runModeTransition.test.ts
@@ -20,6 +20,8 @@ vi.mock("@clack/prompts", () => ({
 	spinner: vi.fn(),
 }));
 
+vi.mock("bingo-fs");
+
 const mockPrepareOptions = vi.fn();
 
 vi.mock("../../preparation/prepareOptions.js", () => ({

--- a/packages/bingo/src/cli/transition/runModeTransition.ts
+++ b/packages/bingo/src/cli/transition/runModeTransition.ts
@@ -1,3 +1,5 @@
+import { intakeDirectory } from "bingo-fs";
+
 import { createSystemContextWithAuth } from "../../contexts/createSystemContextWithAuth.js";
 import { prepareOptions } from "../../preparation/prepareOptions.js";
 import { runTemplate } from "../../runners/runTemplate.js";
@@ -118,6 +120,10 @@ export async function runModeTransition<
 		return { status: CLIStatus.Cancelled };
 	}
 
+	const files = await intakeDirectory(directory, {
+		exclude: /node_modules|^\.git$/,
+	});
+
 	const creation = await runSpinnerTask(
 		display,
 		`Running ${from}`,
@@ -126,6 +132,7 @@ export async function runModeTransition<
 			await runTemplate(template, {
 				...system,
 				directory,
+				files,
 				mode: "transition",
 				offline,
 				options: baseOptions.completed,

--- a/packages/bingo/src/producers/produceTemplate.ts
+++ b/packages/bingo/src/producers/produceTemplate.ts
@@ -1,3 +1,4 @@
+import { IntakeDirectory } from "bingo-fs";
 import { BingoSystem } from "bingo-systems";
 
 import { createSystemContext } from "../contexts/createSystemContext.js";
@@ -17,6 +18,11 @@ export interface ProduceTemplateSettings<
 	OptionsShape extends AnyShape,
 	Refinements,
 > extends Partial<BingoSystem> {
+	/**
+	 * Existing file creations, if in transition mode.
+	 */
+	files?: IntakeDirectory;
+
 	/**
 	 * Which repository mode Bingo is being run in.
 	 * @see {@link https://create.bingo/build/concepts/modes}

--- a/packages/bingo/src/runners/runTemplate.ts
+++ b/packages/bingo/src/runners/runTemplate.ts
@@ -1,3 +1,4 @@
+import { IntakeDirectory } from "bingo-fs";
 import { BingoSystem } from "bingo-systems";
 import fs from "node:fs/promises";
 
@@ -21,6 +22,11 @@ export interface RunTemplateSettings<OptionsShape extends AnyShape, Refinements>
 	 * Current working directory ("cwd") path to use for the file system and running scripts.
 	 */
 	directory?: string;
+
+	/**
+	 * Existing file creations, if in transition mode.
+	 */
+	files?: IntakeDirectory;
 
 	/**
 	 * Which repository mode Bingo is being run in.

--- a/packages/site/src/content/docs/build/packages/bingo-fs.mdx
+++ b/packages/site/src/content/docs/build/packages/bingo-fs.mdx
@@ -44,7 +44,7 @@ Values are the file or directory underneath that key.
 
 ### `IntakeDirectory`
 
-Directories read in from [`intake`](#intake) or [`intakeDirectory`](#intake-directory) are represented as `IntakeDirectory` objects.
+Directories read in from [`intake`](#intake) or [`intakeDirectory`](#intakedirectory) are represented as `IntakeDirectory` objects.
 `IntakeDirectory` objects represent files as `[string, CreatedFileMetadata?]` tuples.
 
 ## Files
@@ -128,10 +128,10 @@ Returns the directory or file if it existed, or `undefined` if it didn't.
 For example, retrieving all files in a `src/` directory:
 
 ```ts
-import { intake } from "bingo-fs";
+import { intakeDirectory } from "bingo-fs";
 
 // { "index.ts": "..." }
-await intake("src");
+await intakeDirectory("src");
 ```
 
 #### `exclude` {#intakedirectory-exclude}
@@ -141,10 +141,10 @@ An optional regular expression to filter out directory children.
 For example, you may want to avoid `.git` and `node_modules` directories:
 
 ```ts
-import { intake } from "bingo-fs";
+import { intakeDirectory } from "bingo-fs";
 
 // Result: { README.md: "...", src: { "index.ts": "..." }, ... }
-await intake(".", {
+await intakeDirectory(".", {
 	exclude: /node_modules|^\.git$/,
 });
 ```

--- a/packages/site/src/content/docs/build/packages/bingo-fs.mdx
+++ b/packages/site/src/content/docs/build/packages/bingo-fs.mdx
@@ -42,6 +42,11 @@ Directories in a `files` object are represented as objects.
 Property keys are the names of children.
 Values are the file or directory underneath that key.
 
+### `IntakeDirectory`
+
+Directories read in from [`intake`](#intake) or [`intakeDirectory`](#intake-directory) are represented as `IntakeDirectory` objects.
+`IntakeDirectory` objects represent files as `[string, CreatedFileMetadata?]` tuples.
+
 ## Files
 
 > TypeScript type name: `CreatedFileEntry`
@@ -51,7 +56,7 @@ Each property value in a directory object may be one of the following:
 - `false` or `undefined`: Ignored
 - `object`: A directory, whose properties recursively are file creations
 - `string`: A file to be created
-- `[string, CreatedFileMetadata]`: A file to be created with options:
+- `[string, CreatedFileMetadata?]`: A file to be created with options:
   - `executable`: Whether to add permissions to make the file executable
 
 For example, this Bingo template produces an executable `.husky/pre-commit` file:
@@ -78,7 +83,7 @@ Given a directory or file path, reads it in as a `bingo-fs` directory structure 
 
 Parameters:
 
-1. `directoryPath: string` _(required)_
+1. `rootPath: string` _(required)_
 2. `settings: IntakeSettings` _(optional)_:
    - [`exclude: RegExp`](#intake-exclude)
 
@@ -94,6 +99,42 @@ await intake("src");
 ```
 
 #### `exclude` {#intake-exclude}
+
+An optional regular expression to filter out directory children.
+
+For example, you may want to avoid `.git` and `node_modules` directories:
+
+```ts
+import { intake } from "bingo-fs";
+
+// Result: { README.md: "...", src: { "index.ts": "..." }, ... }
+await intake(".", {
+	exclude: /node_modules|^\.git$/,
+});
+```
+
+### `intakeDirectory`
+
+Given a directory path, reads it in as a `bingo-fs` directory structure.
+
+Parameters:
+
+1. `directoryPath: string` _(required)_
+2. `settings: IntakeSettings` _(optional)_:
+   - [`exclude: RegExp`](#intake-exclude)
+
+Returns the directory or file if it existed, or `undefined` if it didn't.
+
+For example, retrieving all files in a `src/` directory:
+
+```ts
+import { intake } from "bingo-fs";
+
+// { "index.ts": "..." }
+await intake("src");
+```
+
+#### `exclude` {#intakedirectory-exclude}
 
 An optional regular expression to filter out directory children.
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #338
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/bingo/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/bingo/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Uses the now-exported `intakeDirectory` from `bingo-fs` to read in existing files in `runModeTransition`. Goes with the suggested default exclusion of `node_modules` and `.git`.

Doesn't (yet?) mention the `files` option in `produceTemplate` and co. I'm not sure I want this to be something folks rely on.

🎁 