### PR TITLE
fix(bingo): normalize Clack log step lines again

### DIFF
--- a/packages/bingo/src/cli/display/createClackDisplay.ts
+++ b/packages/bingo/src/cli/display/createClackDisplay.ts
@@ -25,6 +25,8 @@ export function createClackDisplay(): ClackDisplay {
 			Object.assign(groups.get(group).get(id), item);
 		},
 		log(message) {
+			// TODO: file bug? on clack that there's an extra line
+			process.stdout.moveCursor(0, -1);
 			prompts.log.step(message + "\n");
 		},
 	} satisfies Display;

--- a/packages/bingo/src/cli/display/createClackDisplay.ts
+++ b/packages/bingo/src/cli/display/createClackDisplay.ts
@@ -25,7 +25,6 @@ export function createClackDisplay(): ClackDisplay {
 			Object.assign(groups.get(group).get(id), item);
 		},
 		log(message) {
-			// TODO: file bug? on clack that there's an extra line
 			process.stdout.moveCursor(0, -1);
 			prompts.log.step(message + "\n");
 		},


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #318
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/bingo/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/bingo/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Turns out the `process.stdout.moveCursor(0, -1)` was necessary after all. It normalized the distance between steps by effectively getting rid of an excess `\n`.

It was previously removed in https://github.com/JoshuaKGoldberg/bingo/pull/290/files#diff-bc82b0e595cefc1669bca9a8c34172cf6e5c15571e64111bd66bc9dc79d4ee37L28

💝 