### PR TITLE
fix: don't assume process.stdout.moveCursor exists

### DIFF
--- a/packages/bingo/src/cli/display/createClackDisplay.ts
+++ b/packages/bingo/src/cli/display/createClackDisplay.ts
@@ -25,7 +25,9 @@ export function createClackDisplay(): ClackDisplay {
 			Object.assign(groups.get(group).get(id), item);
 		},
 		log(message) {
-			process.stdout.moveCursor(0, -1);
+			// https://github.com/JoshuaKGoldberg/bingo/issues/343
+			// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+			process.stdout.moveCursor?.(0, -1);
 			prompts.log.step(message + "\n");
 		},
 	} satisfies Display;


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #343
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/bingo/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/bingo/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

💝 