### PR TITLE
fix: don't hardcode Prettier formatting

### DIFF
--- a/packages/bingo-stratum/src/runners/runBlock.test.ts
+++ b/packages/bingo-stratum/src/runners/runBlock.test.ts
@@ -63,8 +63,7 @@ describe("runBlock", () => {
 			  "writeFile": [
 			    [
 			      "README.md",
-			      "# abc
-			",
+			      "# abc",
 			    ],
 			  ],
 			}
@@ -139,9 +138,7 @@ describe("runBlock", () => {
 				    [
 				      "README.md",
 				      "# abc
-
-				def
-				",
+				def",
 				    ],
 				  ],
 				}

--- a/packages/bingo/package.json
+++ b/packages/bingo/package.json
@@ -38,7 +38,6 @@
 		"hash-object": "^5.0.1",
 		"hosted-git-info": "^8.0.2",
 		"new-github-repository": "^0.2.1",
-		"prettier": "3.5.3",
 		"read-package-up": "^11.0.0",
 		"read-pkg": "^9.0.1",
 		"slugify": "^1.6.6",

--- a/packages/bingo/src/runners/applyFilesToSystem.ts
+++ b/packages/bingo/src/runners/applyFilesToSystem.ts
@@ -1,7 +1,6 @@
 import { CreatedDirectory } from "bingo-fs";
 import { WritingFileSystem } from "bingo-systems";
 import * as path from "node:path";
-import prettier from "prettier";
 
 export async function applyFilesToSystem(
 	files: CreatedDirectory,
@@ -9,38 +8,6 @@ export async function applyFilesToSystem(
 	directory: string,
 ) {
 	await writeToSystemWorker(files, system, directory);
-}
-
-async function format(fileName: string, text: string) {
-	const parser = inferParser(fileName, text);
-	if (!parser) {
-		return text;
-	}
-
-	return await prettier.format(text, {
-		parser,
-		useTabs: true,
-	});
-}
-
-function inferParser(fileName: string, text: string) {
-	if (text.startsWith("{")) {
-		return "json";
-	}
-
-	switch (fileName.split(".").at(-1)) {
-		case "cjs":
-		case "js":
-			return "babel";
-		case "json":
-			return "json";
-		case "md":
-			return "markdown";
-		case "yml":
-			return "yaml";
-	}
-
-	return undefined;
 }
 
 async function writeToSystemWorker(
@@ -52,14 +19,11 @@ async function writeToSystemWorker(
 
 	for (const [fileName, contents] of Object.entries(files)) {
 		if (typeof contents === "string") {
-			await system.writeFile(
-				path.join(basePath, fileName),
-				await format(fileName, contents),
-			);
+			await system.writeFile(path.join(basePath, fileName), contents);
 		} else if (Array.isArray(contents)) {
 			await system.writeFile(
 				path.join(basePath, fileName),
-				await format(fileName, contents[0]),
+				contents[0],
 				contents[1],
 			);
 		} else if (typeof contents === "object") {

--- a/packages/bingo/src/runners/runTemplate.test.ts
+++ b/packages/bingo/src/runners/runTemplate.test.ts
@@ -61,8 +61,7 @@ describe("runTemplate", () => {
 			  "writeFile": [
 			    [
 			      "README.md",
-			      "# abc
-			",
+			      "# abc",
 			    ],
 			  ],
 			}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,9 +140,6 @@ importers:
       new-github-repository:
         specifier: ^0.2.1
         version: 0.2.1
-      prettier:
-        specifier: 3.5.3
-        version: 3.5.3
       read-package-up:
         specifier: ^11.0.0
         version: 11.0.0


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #350
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/bingo/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/bingo/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Removes `prettier` as a dependency from `bingo` altogether. Files are written with their created text, directly.

On the bright side, file formatting wasn't seriously unit tested before, so this will increase coverage! 😄 

💝 