### PR TITLE
chore: correct Vitest workspace includes

### DIFF
--- a/packages/bingo-fs/vitest.config.ts
+++ b/packages/bingo-fs/vitest.config.ts
@@ -1,7 +1,0 @@
-import { defineProject } from "vitest/config";
-
-export default defineProject({
-	test: {
-		clearMocks: true,
-	},
-});

--- a/packages/bingo-handlebars/vitest.config.ts
+++ b/packages/bingo-handlebars/vitest.config.ts
@@ -1,7 +1,0 @@
-import { defineProject } from "vitest/config";
-
-export default defineProject({
-	test: {
-		clearMocks: true,
-	},
-});

--- a/packages/bingo-requests/vitest.config.ts
+++ b/packages/bingo-requests/vitest.config.ts
@@ -1,7 +1,0 @@
-import { defineProject } from "vitest/config";
-
-export default defineProject({
-	test: {
-		clearMocks: true,
-	},
-});

--- a/packages/bingo-stratum-testers/vitest.config.ts
+++ b/packages/bingo-stratum-testers/vitest.config.ts
@@ -1,7 +1,0 @@
-import { defineProject } from "vitest/config";
-
-export default defineProject({
-	test: {
-		clearMocks: true,
-	},
-});

--- a/packages/bingo-stratum/vitest.config.ts
+++ b/packages/bingo-stratum/vitest.config.ts
@@ -1,7 +1,0 @@
-import { defineProject } from "vitest/config";
-
-export default defineProject({
-	test: {
-		clearMocks: true,
-	},
-});

--- a/packages/bingo-systems/vitest.config.ts
+++ b/packages/bingo-systems/vitest.config.ts
@@ -1,7 +1,0 @@
-import { defineProject } from "vitest/config";
-
-export default defineProject({
-	test: {
-		clearMocks: true,
-	},
-});

--- a/packages/bingo-testers/vitest.config.ts
+++ b/packages/bingo-testers/vitest.config.ts
@@ -1,7 +1,0 @@
-import { defineProject } from "vitest/config";
-
-export default defineProject({
-	test: {
-		clearMocks: true,
-	},
-});

--- a/packages/bingo/vitest.config.ts
+++ b/packages/bingo/vitest.config.ts
@@ -1,7 +1,0 @@
-import { defineProject } from "vitest/config";
-
-export default defineProject({
-	test: {
-		clearMocks: true,
-	},
-});

--- a/packages/input-from-fetch/vitest.config.ts
+++ b/packages/input-from-fetch/vitest.config.ts
@@ -1,7 +1,0 @@
-import { defineProject } from "vitest/config";
-
-export default defineProject({
-	test: {
-		clearMocks: true,
-	},
-});

--- a/packages/input-from-file-json/vitest.config.ts
+++ b/packages/input-from-file-json/vitest.config.ts
@@ -1,7 +1,0 @@
-import { defineProject } from "vitest/config";
-
-export default defineProject({
-	test: {
-		clearMocks: true,
-	},
-});

--- a/packages/input-from-file/vitest.config.ts
+++ b/packages/input-from-file/vitest.config.ts
@@ -1,7 +1,0 @@
-import { defineProject } from "vitest/config";
-
-export default defineProject({
-	test: {
-		clearMocks: true,
-	},
-});

--- a/packages/input-from-script/vitest.config.ts
+++ b/packages/input-from-script/vitest.config.ts
@@ -1,7 +1,0 @@
-import { defineProject } from "vitest/config";
-
-export default defineProject({
-	test: {
-		clearMocks: true,
-	},
-});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,24 +1,26 @@
-import { defineConfig } from "vitest/config";
+import { readdirSync } from "node:fs";
+import { coverageConfigDefaults, defineConfig } from "vitest/config";
 
 export default defineConfig({
 	test: {
 		coverage: {
 			all: true,
-			exclude: ["**/.*/", "**/*.config.*", "**/*.d.ts"],
+			exclude: [
+				...coverageConfigDefaults.exclude,
+				"**/config.ts",
+				"**/*.astro",
+			],
+			include: ["packages/*/src/"],
 		},
-		exclude: ["packages/*/lib"],
-		include: ["packages/*/src/**/*.ts"],
-		setupFiles: ["console-fail-test/setup"],
-		workspace: [
-			"packages/*",
-			{
-				test: {
-					clearMocks: true,
-					exclude: ["packages/*/lib"],
-					include: ["packages/*/src"],
-					setupFiles: ["console-fail-test/setup"],
-				},
+
+		workspace: readdirSync("./packages").map((name) => ({
+			test: {
+				clearMocks: true,
+				include: ["**/src/**/*.test.ts"],
+				name,
+				root: `./packages/${name}`,
+				setupFiles: ["console-fail-test/setup"],
 			},
-		],
+		})),
 	},
 });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #373
- [x] That issue was marked as [`status: accepting prs`](https://github.com/bingo-js/bingo/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/bingo-js/bingo/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Switches the root Vitest config to:

* Use `coverage.exclude` with `coverageConfigDefaults.exclude`
* Set `name` and `root` in each workspace based on the directory name

This is 100% a copy & paste of @AriPerkkio's suggestion in the issue's linked Discord thread. Therefore:

Co-authored-by: @AriPerkkio

💝 