### PR TITLE
feat: fold --skip-github into --skip-requests

### DIFF
--- a/packages/bingo/src/cli/parseProcessArgv.ts
+++ b/packages/bingo/src/cli/parseProcessArgv.ts
@@ -27,9 +27,6 @@ const cliArgsOptions = {
 	"skip-files": {
 		type: "boolean",
 	},
-	"skip-github": {
-		type: "boolean",
-	},
 	"skip-requests": {
 		type: "boolean",
 	},
@@ -49,7 +46,6 @@ export interface RunCLIRawValues {
 	owner?: boolean | string | undefined;
 	repository?: boolean | string | undefined;
 	"skip-files"?: boolean | string | undefined;
-	"skip-github"?: boolean | string | undefined;
 	"skip-requests"?: boolean | string | undefined;
 	"skip-scripts"?: boolean | string | undefined;
 	version?: boolean | string | undefined;

--- a/packages/bingo/src/cli/runCLI.ts
+++ b/packages/bingo/src/cli/runCLI.ts
@@ -20,7 +20,6 @@ const valuesSchema = z.object({
 	owner: z.string().optional(),
 	repository: z.string().optional(),
 	"skip-files": z.boolean().optional(),
-	"skip-github": z.boolean().optional(),
 	"skip-requests": z.boolean().optional(),
 	"skip-scripts": z.boolean().optional(),
 });
@@ -60,7 +59,6 @@ export async function runCLI<OptionsShape extends AnyShape, Refinements>({
 		from,
 		skips: {
 			files: validatedValues["skip-files"],
-			github: validatedValues["skip-github"],
 			requests: validatedValues["skip-requests"],
 			scripts: validatedValues["skip-scripts"],
 		},

--- a/packages/bingo/src/cli/runCli.test.ts
+++ b/packages/bingo/src/cli/runCli.test.ts
@@ -149,30 +149,6 @@ describe("runCli", () => {
 		);
 	});
 
-	it("provides skips.github when --skip-github is provided", async () => {
-		mockReadProductionSettings.mockResolvedValueOnce({
-			mode: "setup",
-		});
-
-		await runCLI({
-			argv,
-			display: createClackDisplay(),
-			from: "",
-			template,
-			values: {
-				"skip-github": true,
-			},
-		});
-
-		expect(mockRunModeSetup).toHaveBeenCalledWith(
-			expect.objectContaining({
-				skips: {
-					github: true,
-				},
-			}),
-		);
-	});
-
 	it("provides skips.requests when --skip-requests is provided", async () => {
 		mockReadProductionSettings.mockResolvedValueOnce({
 			mode: "setup",

--- a/packages/bingo/src/cli/setup/runModeSetup.test.ts
+++ b/packages/bingo/src/cli/setup/runModeSetup.test.ts
@@ -177,6 +177,53 @@ describe("runModeSetup", () => {
 		});
 	});
 
+	it("does not create a repository on GitHub when offline is requested", async () => {
+		mockPromptForDirectory.mockResolvedValueOnce("test-directory");
+		mockPromptForOptionSchemas.mockResolvedValueOnce({
+			prompted: {},
+		});
+		mockRunTemplate.mockResolvedValueOnce({});
+
+		const actual = await runModeSetup({
+			argv,
+			display,
+			from,
+			offline: true,
+			template,
+		});
+
+		expect(mockCreateRepositoryOnGitHub).not.toHaveBeenCalled();
+
+		expect(actual).toEqual({
+			outro: `Thanks for using ${chalk.bgGreenBright.black(from)}! 💝`,
+			status: CLIStatus.Success,
+			suggestions: undefined,
+		});
+	});
+
+	it("does not create a repository on GitHub when skips.requests is true", async () => {
+		mockPromptForDirectory.mockResolvedValueOnce("test-directory");
+		mockPromptForOptionSchemas.mockResolvedValueOnce({
+			prompted: {},
+		});
+		mockRunTemplate.mockResolvedValueOnce({});
+
+		const actual = await runModeSetup({
+			argv,
+			display,
+			from,
+			skips: { requests: true },
+			template,
+		});
+
+		expect(mockCreateRepositoryOnGitHub).not.toHaveBeenCalled();
+		expect(actual).toEqual({
+			outro: `Thanks for using ${chalk.bgGreenBright.black(from)}! 💝`,
+			status: CLIStatus.Success,
+			suggestions: undefined,
+		});
+	});
+
 	it("returns an error status when online and creating a repository errors", async () => {
 		mockPromptForDirectory.mockResolvedValueOnce("test-directory");
 		mockPromptForOptionSchemas.mockResolvedValueOnce({

--- a/packages/bingo/src/cli/setup/runModeSetup.ts
+++ b/packages/bingo/src/cli/setup/runModeSetup.ts
@@ -62,7 +62,7 @@ export async function runModeSetup<OptionsShape extends AnyShape, Refinements>({
 	const system = await createSystemContextWithAuth({
 		directory,
 		display,
-		offline: requestedOffline || skips.github,
+		offline: requestedOffline,
 	});
 
 	const providedOptions = parseZodArgs(argv, {
@@ -107,14 +107,21 @@ export async function runModeSetup<OptionsShape extends AnyShape, Refinements>({
 	const { offline, remote, warning } =
 		requestedOffline || !system.fetchers.octokit
 			? { offline: true, remote: undefined }
-			: await createRepositoryOnGitHub(
-					display,
-					{ repository, ...baseOptions.completed },
-					requestedOffline,
-					system.fetchers.octokit,
-					system.runner,
-					template,
-				);
+			: skips.requests
+				? {
+						offline: false,
+						remote: undefined,
+						warning:
+							"Running without creating a repository on GitHub due to --skip-requests.",
+					}
+				: await createRepositoryOnGitHub(
+						display,
+						{ repository, ...baseOptions.completed },
+						requestedOffline,
+						system.fetchers.octokit,
+						system.runner,
+						template,
+					);
 
 	if (remote instanceof Error) {
 		logRerunSuggestion(argv, baseOptions.prompted);

--- a/packages/bingo/src/cli/transition/runModeTransition.ts
+++ b/packages/bingo/src/cli/transition/runModeTransition.ts
@@ -53,7 +53,7 @@ export async function runModeTransition<
 	const system = await createSystemContextWithAuth({
 		directory,
 		display,
-		offline: offline || skips.github,
+		offline,
 	});
 
 	const repositoryLocator =

--- a/packages/bingo/src/types/skips.ts
+++ b/packages/bingo/src/types/skips.ts
@@ -8,11 +8,6 @@ export interface RequestedSkips {
 	files?: boolean;
 
 	/**
-	 * Whether to opt out of creating and updating a GitHub repository.
-	 */
-	github?: boolean;
-
-	/**
 	 * Whether to opt out of sending network requests.
 	 */
 	requests?: boolean;

--- a/packages/site/src/content/docs/cli.mdx
+++ b/packages/site/src/content/docs/cli.mdx
@@ -94,35 +94,12 @@ For example, specifying updating all of repository except its files with [`creat
 
 <PackageManagers type="dlx" pkg="create-typescript-app" args="--skip-files" />
 
-### `--skip-github`
-
-> Type: `boolean`
-
-Whether to skip creating or updating a repository on GitHub.
-
-This can be useful if you want to keep all your changes local and not publish anything on GitHub.
-
-For example, creating repository locally with [`create-typescript-app`](https://github.com/JoshuaKGoldberg/create-typescript-app):
-
-<PackageManagers type="dlx" pkg="create-typescript-app" args="--skip-github" />
-
-`--skip-github` effectively defaults to true if [`--offline`](#--offline) is provided.
-However, it does not prevent network requests from being made the way [`--offline`](#--offline) or [`--skip-requests`](#--skip-requests) do.
-
-:::note
-`--skip-github` will soon default to `true` for new repositories (setup mode).
-Creating a repository on GitHub in setup mode will switch to opt-in, rather than opt-out, behavior.
-:::
-
 ### `--skip-requests`
 
 > Type: `boolean`
 
 Whether to skip sending network requests as specified by templates.
-
-`--skip-requests` effectively defaults to true if [`--offline`](#--offline) is provided.
-However, it does not prevent network requests from being sent by other parts of templates.
-For example, templates may run package installation scripts that don't include their own `--offline` flag when Bingo's [`--offline`](#--offline) is not provided.
+In setup mode, this includes creating a repository on GitHub.
 
 For example, creating a repository using [`create-typescript-app`](https://github.com/JoshuaKGoldberg/create-typescript-app) without populating network requests, but with network installation of packages (`pnpm install` instead of `pnpm install --offline`):
 
@@ -131,6 +108,15 @@ For example, creating a repository using [`create-typescript-app`](https://githu
 	pkg="create-typescript-app"
 	args="--skip-requests"
 />
+
+`--skip-requests` effectively defaults to true if [`--offline`](#--offline) is provided.
+However, it does not prevent network requests from being sent by other parts of templates.
+For example, templates may run package installation scripts that don't include their own `--offline` flag when Bingo's [`--offline`](#--offline) is not provided.
+
+:::note
+`--skip-requests` will soon default to `true` for new repositories (setup mode).
+Creating a repository on GitHub in setup mode will switch to opt-in, rather than opt-out, behavior.
+:::
 
 ### `--skip-scripts`
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #382
- [x] That issue was marked as [`status: accepting prs`](https://github.com/bingo-js/bingo/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/bingo-js/bingo/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Removes `--skip-github` altogether, moving its docs notes and functionality into `--skip-requests`.

💝 
