### PR TITLE
feat: skip git initialization when already in a git repository

### DIFF
--- a/packages/bingo/src/cli/isInGitRepository.test.ts
+++ b/packages/bingo/src/cli/isInGitRepository.test.ts
@@ -6,7 +6,7 @@ describe("isInGitRepository", () => {
 	it("returns true when git rev-parse --git-dir has stdout", async () => {
 		const runner = vi.fn().mockResolvedValueOnce({ stdout: "/.git" });
 
-		await isInGitRepository(runner);
+		expect(await isInGitRepository(runner)).toBe(true);
 
 		expect(runner).toHaveBeenCalledTimes(1);
 		expect(runner).toHaveBeenCalledWith(`git rev-parse --git-dir`);
@@ -17,7 +17,7 @@ describe("isInGitRepository", () => {
 			.fn()
 			.mockRejectedValueOnce(new Error("Not a Git repository"));
 
-		await isInGitRepository(runner);
+		expect(await isInGitRepository(runner)).toBe(false);
 
 		expect(runner).toHaveBeenCalledTimes(1);
 		expect(runner).toHaveBeenCalledWith(`git rev-parse --git-dir`);

--- a/packages/bingo/src/cli/isInGitRepository.test.ts
+++ b/packages/bingo/src/cli/isInGitRepository.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { isInGitRepository } from "./isInGitRepository.js";
+
+describe("isInGitRepository", () => {
+	it("returns true when git rev-parse --git-dir has stdout", async () => {
+		const runner = vi.fn().mockResolvedValueOnce({ stdout: "/.git" });
+
+		await isInGitRepository(runner);
+
+		expect(runner).toHaveBeenCalledTimes(1);
+		expect(runner).toHaveBeenCalledWith(`git rev-parse --git-dir`);
+	});
+
+	it("returns false when git rev-parse --git-dir has no stdout", async () => {
+		const runner = vi
+			.fn()
+			.mockRejectedValueOnce(new Error("Not a Git repository"));
+
+		await isInGitRepository(runner);
+
+		expect(runner).toHaveBeenCalledTimes(1);
+		expect(runner).toHaveBeenCalledWith(`git rev-parse --git-dir`);
+	});
+});

--- a/packages/bingo/src/cli/isInGitRepository.ts
+++ b/packages/bingo/src/cli/isInGitRepository.ts
@@ -1,0 +1,10 @@
+import { SystemRunner } from "bingo-systems";
+
+export async function isInGitRepository(runner: SystemRunner) {
+	try {
+		await runner("git rev-parse --git-dir");
+		return true;
+	} catch {
+		return false;
+	}
+}

--- a/packages/bingo/src/cli/setup/runModeSetup.test.ts
+++ b/packages/bingo/src/cli/setup/runModeSetup.test.ts
@@ -65,9 +65,17 @@ vi.mock("../createInitialCommit.js", () => ({
 
 const mockCreateTrackingBranches = vi.fn();
 
-vi.mock("../createTrackingBranches.js", () => ({
+vi.mock("./createTrackingBranches.js", () => ({
 	get createTrackingBranches() {
 		return mockCreateTrackingBranches;
+	},
+}));
+
+const mockIsInGitRepository = vi.fn();
+
+vi.mock("../isInGitRepository.js", () => ({
+	get isInGitRepository() {
+		return mockIsInGitRepository;
 	},
 }));
 
@@ -183,6 +191,7 @@ describe("runModeSetup", () => {
 			prompted: {},
 		});
 		mockRunTemplate.mockResolvedValueOnce({});
+		mockIsInGitRepository.mockResolvedValueOnce(false);
 
 		const actual = await runModeSetup({
 			argv,
@@ -207,6 +216,7 @@ describe("runModeSetup", () => {
 			prompted: {},
 		});
 		mockRunTemplate.mockResolvedValueOnce({});
+		mockIsInGitRepository.mockResolvedValueOnce(false);
 
 		const actual = await runModeSetup({
 			argv,
@@ -253,6 +263,7 @@ describe("runModeSetup", () => {
 		});
 		mockCreateRepositoryOnGitHub.mockResolvedValueOnce({});
 		mockRunTemplate.mockResolvedValueOnce({});
+		mockIsInGitRepository.mockResolvedValueOnce(false);
 
 		const actual = await runModeSetup({
 			argv,
@@ -261,6 +272,32 @@ describe("runModeSetup", () => {
 			template,
 		});
 
+		expect(actual).toEqual({
+			outro: `Thanks for using ${chalk.bgGreenBright.black(from)}! 💝`,
+			status: CLIStatus.Success,
+			suggestions: undefined,
+		});
+	});
+
+	it("skips git initialization when already in a git repository", async () => {
+		mockPromptForDirectory.mockResolvedValueOnce("test-directory");
+		mockPromptForOptionSchemas.mockResolvedValueOnce({
+			prompted: {},
+		});
+		mockCreateRepositoryOnGitHub.mockResolvedValueOnce({});
+		mockRunTemplate.mockResolvedValueOnce({});
+		mockIsInGitRepository.mockResolvedValueOnce(true);
+
+		const actual = await runModeSetup({
+			argv,
+			display,
+			from,
+			template,
+		});
+
+		expect(mockCreateTrackingBranches).not.toHaveBeenCalled();
+		expect(mockCreateInitialCommit).not.toHaveBeenCalled();
+		expect(mockClearLocalGitTags).not.toHaveBeenCalled();
 		expect(actual).toEqual({
 			outro: `Thanks for using ${chalk.bgGreenBright.black(from)}! 💝`,
 			status: CLIStatus.Success,

--- a/packages/bingo/src/cli/setup/runModeSetup.ts
+++ b/packages/bingo/src/cli/setup/runModeSetup.ts
@@ -12,6 +12,7 @@ import { clearLocalGitTags } from "../clearLocalGitTags.js";
 import { createInitialCommit } from "../createInitialCommit.js";
 import { ClackDisplay } from "../display/createClackDisplay.js";
 import { runSpinnerTask } from "../display/runSpinnerTask.js";
+import { isInGitRepository } from "../isInGitRepository.js";
 import { logRerunSuggestion } from "../loggers/logRerunSuggestion.js";
 import { logStartText } from "../loggers/logStartText.js";
 import { CLIMessage } from "../messages.js";
@@ -23,7 +24,6 @@ import { ModeResults } from "../types.js";
 import { makeRelative } from "../utils.js";
 import { createRepositoryOnGitHub } from "./createRepositoryOnGitHub.js";
 import { createTrackingBranches } from "./createTrackingBranches.js";
-import { isInGitRepository } from "../isInGitRepository.js";
 
 export interface RunModeSetupSettings<
 	OptionsShape extends AnyShape,

--- a/packages/bingo/src/cli/setup/runModeSetup.ts
+++ b/packages/bingo/src/cli/setup/runModeSetup.ts
@@ -160,16 +160,15 @@ export async function runModeSetup<OptionsShape extends AnyShape, Refinements>({
 	const preparationError = (await isInGitRepository(system.runner))
 		? undefined
 		: await runSpinnerTask(
-			display,
-			"Preparing local repository",
-			"Prepared local repository",
-			async () => {
-				await createTrackingBranches(remote, system.runner);
-				await createInitialCommit(system.runner, { push: !!remote });
-				await clearLocalGitTags(system.runner);
-			},
-		);
-	}
+				display,
+				"Preparing local repository",
+				"Prepared local repository",
+				async () => {
+					await createTrackingBranches(remote, system.runner);
+					await createInitialCommit(system.runner, { push: !!remote });
+					await clearLocalGitTags(system.runner);
+				},
+			);
 
 	prompts.log.message(
 		[

--- a/packages/bingo/src/cli/setup/runModeSetup.ts
+++ b/packages/bingo/src/cli/setup/runModeSetup.ts
@@ -157,10 +157,9 @@ export async function runModeSetup<OptionsShape extends AnyShape, Refinements>({
 		};
 	}
 
-	let preparationError: Error | void = undefined;
-	const isInGitRepo = await isInGitRepository(system.runner);
-	if (!isInGitRepo) {
-		preparationError = await runSpinnerTask(
+	const preparationError = (await isInGitRepository(system.runner))
+		? undefined
+		: await runSpinnerTask(
 			display,
 			"Preparing local repository",
 			"Prepared local repository",


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to Bingo! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #384
- [x] That issue was marked as [`status: accepting prs`](https://github.com/bingo-js/bingo/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/bingo-js/bingo/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
Adds detection to check if the target directory is already within a git repository before running git initialization steps. This prevents errors and unnecessary git operations when running setup in an existing git context.

- Created isInGitRepository utility to detect existing git repos
- Modified runModeSetup to check git status before preparation
- Skip createTrackingBranches, createInitialCommit, and clearLocalGitTags when already in a git repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)