### PR TITLE
fix(bingo): account for successful failures in git rev-parse

### DIFF
--- a/packages/bingo/src/cli/isInGitRepository.test.ts
+++ b/packages/bingo/src/cli/isInGitRepository.test.ts
@@ -3,23 +3,33 @@ import { describe, expect, it, vi } from "vitest";
 import { isInGitRepository } from "./isInGitRepository.js";
 
 describe("isInGitRepository", () => {
-	it("returns true when git rev-parse --git-dir has stdout", async () => {
-		const runner = vi.fn().mockResolvedValueOnce({ stdout: "/.git" });
+	it("returns false when git rev-parse --git-dir has no message", async () => {
+		const runner = vi.fn().mockResolvedValueOnce({
+			message: undefined,
+		});
 
-		expect(await isInGitRepository(runner)).toBe(true);
+		const actual = await isInGitRepository(runner);
 
-		expect(runner).toHaveBeenCalledTimes(1);
-		expect(runner).toHaveBeenCalledWith(`git rev-parse --git-dir`);
+		expect(actual).toBe(false);
 	});
 
-	it("returns false when git rev-parse --git-dir has no stdout", async () => {
-		const runner = vi
-			.fn()
-			.mockRejectedValueOnce(new Error("Not a Git repository"));
+	it("returns false when git rev-parse --git-dir has explicit non-Git stdout", async () => {
+		const runner = vi.fn().mockResolvedValueOnce({
+			message: "fatal: not a git repository ...",
+		});
 
-		expect(await isInGitRepository(runner)).toBe(false);
+		const actual = await isInGitRepository(runner);
 
-		expect(runner).toHaveBeenCalledTimes(1);
-		expect(runner).toHaveBeenCalledWith(`git rev-parse --git-dir`);
+		expect(actual).toBe(false);
+	});
+
+	it("returns true when git rev-parse --git-dir has Git-related stdout", async () => {
+		const runner = vi.fn().mockResolvedValueOnce({
+			message: "/.git",
+		});
+
+		const actual = await isInGitRepository(runner);
+
+		expect(actual).toBe(true);
 	});
 });

--- a/packages/bingo/src/cli/isInGitRepository.ts
+++ b/packages/bingo/src/cli/isInGitRepository.ts
@@ -1,10 +1,8 @@
 import { SystemRunner } from "bingo-systems";
 
 export async function isInGitRepository(runner: SystemRunner) {
-	try {
-		await runner("git rev-parse --git-dir");
-		return true;
-	} catch {
-		return false;
-	}
+	const result = await runner("git rev-parse --git-dir");
+	return result.message
+		? !result.message.includes("fatal: not a git repository")
+		: false;
 }


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #391
- [x] That issue was marked as [`status: accepting prs`](https://github.com/bingo-js/bingo/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/bingo-js/bingo/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

If the CLI is being run outside of a Git repository, the runner will be an object matching roughly `{ message: "fatal: not a git repository ..." }`.

💝 