### PR TITLE
fix(bingo): override initial commit in transition mode again

### DIFF
--- a/packages/bingo/src/cli/transition/runModeTransition.ts
+++ b/packages/bingo/src/cli/transition/runModeTransition.ts
@@ -161,25 +161,20 @@ export async function runModeTransition({
 		};
 	}
 
-	if (!repositoryLocator) {
-		logRerunSuggestion(argv, baseOptions.prompted);
-		return {
-			outro: CLIMessage.Done,
-			status: CLIStatus.Success,
-		};
-	}
-
-	const commit = await runSpinnerTask(
-		display,
-		"Creating initial commit",
-		"Created initial commit",
-		async () => {
-			await createInitialCommit(system.runner, {
-				amend: true,
-				push: !offline,
-			});
-		},
-	);
+	const commit =
+		repositoryLocator || requestedRemote
+			? await runSpinnerTask(
+					display,
+					"Creating initial commit",
+					"Created initial commit",
+					async () => {
+						await createInitialCommit(system.runner, {
+							amend: true,
+							push: !offline,
+						});
+					},
+				)
+			: undefined;
 
 	logRerunSuggestion(argv, baseOptions.prompted);
 
@@ -189,7 +184,7 @@ export async function runModeTransition({
 				status: CLIStatus.Error,
 			}
 		: {
-				outro: CLIMessage.New,
+				outro: repositoryLocator ? CLIMessage.New : CLIMessage.Done,
 				status: CLIStatus.Success,
 			};
 }


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #394
- [x] That issue was marked as [`status: accepting prs`](https://github.com/bingo-js/bingo/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/bingo-js/bingo/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Previously, `runModeTransition` exited early if there wasn't a `repositoryLocator` (indicating it's a repo forked from a template). This ignored whether `remote: requestedRemote` was truthy.

Now, the fail fast is removed. The initial commit will be created if there's a `repositoryLocator` _or_ `requestedRemote`.

💝 