### PR TITLE
fix(bingo): update cli help output to reflect new options

### DIFF
--- a/packages/bingo/src/cli/loggers/logHelpText.test.ts
+++ b/packages/bingo/src/cli/loggers/logHelpText.test.ts
@@ -50,6 +50,15 @@ describe("logHelpText", () => {
 			  --offline (boolean): Whether to run in an "offline" mode that skips network requests.
 			      npx ./template.js --offline
 
+			  --remote (boolean): Whether to create a remote repository on GitHub if one does not already exist.
+			      npx ./template.js --remote
+
+			  --skip-files (boolean): Whether to skip creating files on disk.
+			      npx ./template.js --skip-files
+
+			  --skip-requests (boolean): Whether to skip sending network requests as specified by templates.
+			      npx ./template.js --skip-requests
+
 			  --version (boolean): Prints package versions.
 			      npx ./template.js --version
 			",
@@ -100,6 +109,15 @@ describe("logHelpText", () => {
 
 			  --offline (boolean): Whether to run in an "offline" mode that skips network requests.
 			      npx ./template.js --offline
+
+			  --remote (boolean): Whether to create a remote repository on GitHub if one does not already exist.
+			      npx ./template.js --remote
+
+			  --skip-files (boolean): Whether to skip creating files on disk.
+			      npx ./template.js --skip-files
+
+			  --skip-requests (boolean): Whether to skip sending network requests as specified by templates.
+			      npx ./template.js --skip-requests
 
 			  --version (boolean): Prints package versions.
 			      npx ./template.js --version

--- a/packages/bingo/src/cli/loggers/logHelpText.ts
+++ b/packages/bingo/src/cli/loggers/logHelpText.ts
@@ -52,6 +52,24 @@ export function logHelpText<OptionsShape extends AnyShape, Refinements>(
 			type: "boolean",
 		},
 		{
+			examples: ["--remote"],
+			flag: "--remote",
+			text: "Whether to create a remote repository on GitHub if one does not already exist.",
+			type: "boolean",
+		},
+		{
+			examples: ["--skip-files"],
+			flag: "--skip-files",
+			text: "Whether to skip creating files on disk.",
+			type: "boolean",
+		},
+		{
+			examples: ["--skip-requests"],
+			flag: "--skip-requests",
+			text: "Whether to skip sending network requests as specified by templates.",
+			type: "boolean",
+		},
+		{
 			examples: ["--version"],
 			flag: "--version",
 			text: "Prints package versions.",


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #396
- [x] That issue was marked as [`status: accepting prs`](https://github.com/bingo-js/bingo/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22) (Not yet... 😅)
- [x] Steps in [CONTRIBUTING.md](https://github.com/bingo-js/bingo/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds descriptions for recently-added commands ot the CLI `--help` output. I used the strings from [cli.mdx](https://github.com/bingo-js/bingo/blob/6caf53472042da022602c9cb609c951f9ef7b22a/packages/site/src/content/docs/cli.mdx).

⚫