### PR TITLE
feat: report an error on unknown CLI flags

### DIFF
--- a/.changeset/lucky-otters-gather.md
+++ b/.changeset/lucky-otters-gather.md
@@ -1,0 +1,6 @@
+---
+"bingo": minor
+"bingo-stratum": patch
+---
+
+Reported an error on unknown CLI flags, with a suggestion for the closest known flag.

--- a/packages/bingo-stratum/src/creators/createStratumTemplate.test.ts
+++ b/packages/bingo-stratum/src/creators/createStratumTemplate.test.ts
@@ -89,6 +89,37 @@ describe("createStratumTemplate", () => {
 			]);
 		});
 
+		it("adds a block refinement option when a named block is only outside presets", () => {
+			const template = base.createStratumTemplate({
+				blocks: [
+					base.createBlock({
+						about: { name: "Outside Block" },
+						produce: vi.fn(),
+					}),
+				],
+				presets: [
+					base.createPreset({
+						about: { name: "Example Preset" },
+						blocks: [
+							base.createBlock({
+								about: { name: "Example Block" },
+								produce: vi.fn(),
+							}),
+						],
+					}),
+				],
+			});
+
+			expect(Object.keys(template.options)).toEqual([
+				"name",
+				"preset",
+				"add-example-block",
+				"add-outside-block",
+				"exclude-example-block",
+				"exclude-outside-block",
+			]);
+		});
+
 		describe("inference", () => {
 			const templateWithPreset = base.createStratumTemplate({
 				presets: [preset],

--- a/packages/bingo-stratum/src/creators/createStratumTemplate.ts
+++ b/packages/bingo-stratum/src/creators/createStratumTemplate.ts
@@ -25,8 +25,11 @@ export function createStratumTemplate<OptionsShape extends AnyShape>(
 
 	const namedBlocks = Array.from(
 		new Set(
-			templateDefinition.presets
-				.flatMap((preset) => preset.blocks.map((block) => block.about?.name))
+			[
+				...(templateDefinition.blocks ?? []),
+				...templateDefinition.presets.flatMap((preset) => preset.blocks),
+			]
+				.map((block) => block.about?.name)
 				.filter((blockName) => typeof blockName === "string"),
 		),
 	);

--- a/packages/bingo/src/cli/cliArgsOptions.ts
+++ b/packages/bingo/src/cli/cliArgsOptions.ts
@@ -1,0 +1,42 @@
+import { ParseArgsConfig } from "node:util";
+
+// TODO: Send issue/PR to DefinitelyTyped to export these from node:util...
+// https://github.com/bingo-js/bingo/issues/284
+
+type ParseArgsOptionsConfig = NonNullable<ParseArgsConfig["options"]>;
+
+export const cliArgsOptions = {
+	directory: {
+		type: "string",
+	},
+	help: {
+		type: "boolean",
+	},
+	mode: {
+		type: "string",
+	},
+	offline: {
+		type: "boolean",
+	},
+	owner: {
+		type: "string",
+	},
+	remote: {
+		type: "boolean",
+	},
+	repository: {
+		type: "string",
+	},
+	"skip-files": {
+		type: "boolean",
+	},
+	"skip-requests": {
+		type: "boolean",
+	},
+	"skip-scripts": {
+		type: "boolean",
+	},
+	version: {
+		type: "boolean",
+	},
+} satisfies ParseArgsOptionsConfig;

--- a/packages/bingo/src/cli/loggers/logUnknownFlags.test.ts
+++ b/packages/bingo/src/cli/loggers/logUnknownFlags.test.ts
@@ -1,0 +1,47 @@
+import * as prompts from "@clack/prompts";
+import chalk from "chalk";
+import { describe, expect, it, vi } from "vitest";
+
+import { logUnknownFlags } from "./logUnknownFlags.js";
+
+vi.mock("@clack/prompts", () => ({
+	log: {
+		error: vi.fn(),
+	},
+}));
+
+describe(logUnknownFlags, () => {
+	it("logs a suggestion when the unknown flag has one", () => {
+		logUnknownFlags([{ flag: "skip-file", suggestion: "skip-files" }]);
+
+		expect(prompts.log.error).toHaveBeenCalledWith(
+			[
+				`Unknown CLI flag: ${chalk.red("--skip-file")}`,
+				`  Did you mean ${chalk.green("--skip-files")}?`,
+			].join("\n"),
+		);
+	});
+
+	it("logs only the flag when the unknown flag has no suggestion", () => {
+		logUnknownFlags([{ flag: "wat" }]);
+
+		expect(prompts.log.error).toHaveBeenCalledWith(
+			`Unknown CLI flag: ${chalk.red("--wat")}`,
+		);
+	});
+
+	it("logs each flag when multiple unknown flags are provided", () => {
+		logUnknownFlags([
+			{ flag: "skip-file", suggestion: "skip-files" },
+			{ flag: "wat" },
+		]);
+
+		expect(prompts.log.error).toHaveBeenCalledWith(
+			[
+				`Unknown CLI flag: ${chalk.red("--skip-file")}`,
+				`  Did you mean ${chalk.green("--skip-files")}?`,
+				`Unknown CLI flag: ${chalk.red("--wat")}`,
+			].join("\n"),
+		);
+	});
+});

--- a/packages/bingo/src/cli/loggers/logUnknownFlags.test.ts
+++ b/packages/bingo/src/cli/loggers/logUnknownFlags.test.ts
@@ -30,6 +30,14 @@ describe(logUnknownFlags, () => {
 		);
 	});
 
+	it("logs a single dash when the unknown flag is one character", () => {
+		logUnknownFlags([{ flag: "h" }]);
+
+		expect(prompts.log.error).toHaveBeenCalledWith(
+			`Unknown CLI flag: ${chalk.red("-h")}`,
+		);
+	});
+
 	it("logs each flag when multiple unknown flags are provided", () => {
 		logUnknownFlags([
 			{ flag: "skip-file", suggestion: "skip-files" },

--- a/packages/bingo/src/cli/loggers/logUnknownFlags.ts
+++ b/packages/bingo/src/cli/loggers/logUnknownFlags.ts
@@ -8,7 +8,7 @@ export function logUnknownFlags(unknownFlags: UnknownFlag[]) {
 		unknownFlags
 			.map(({ flag, suggestion }) =>
 				[
-					`Unknown CLI flag: ${chalk.red(`--${flag}`)}`,
+					`Unknown CLI flag: ${chalk.red(formatFlagAsWritten(flag))}`,
 					...(suggestion
 						? [`  Did you mean ${chalk.green(`--${suggestion}`)}?`]
 						: []),
@@ -16,4 +16,8 @@ export function logUnknownFlags(unknownFlags: UnknownFlag[]) {
 			)
 			.join("\n"),
 	);
+}
+
+function formatFlagAsWritten(flag: string) {
+	return flag.length === 1 ? `-${flag}` : `--${flag}`;
 }

--- a/packages/bingo/src/cli/loggers/logUnknownFlags.ts
+++ b/packages/bingo/src/cli/loggers/logUnknownFlags.ts
@@ -1,0 +1,19 @@
+import * as prompts from "@clack/prompts";
+import chalk from "chalk";
+
+import { UnknownFlag } from "../parsers/getUnknownFlags.js";
+
+export function logUnknownFlags(unknownFlags: UnknownFlag[]) {
+	prompts.log.error(
+		unknownFlags
+			.map(({ flag, suggestion }) =>
+				[
+					`Unknown CLI flag: ${chalk.red(`--${flag}`)}`,
+					...(suggestion
+						? [`  Did you mean ${chalk.green(`--${suggestion}`)}?`]
+						: []),
+				].join("\n"),
+			)
+			.join("\n"),
+	);
+}

--- a/packages/bingo/src/cli/parseProcessArgv.ts
+++ b/packages/bingo/src/cli/parseProcessArgv.ts
@@ -1,45 +1,6 @@
-import { parseArgs, ParseArgsConfig } from "node:util";
+import { parseArgs } from "node:util";
 
-// TODO: Send issue/PR to DefinitelyTyped to export these from node:util...
-// https://github.com/bingo-js/bingo/issues/284
-
-type ParseArgsOptionsConfig = NonNullable<ParseArgsConfig["options"]>;
-
-const cliArgsOptions = {
-	directory: {
-		type: "string",
-	},
-	help: {
-		type: "boolean",
-	},
-	mode: {
-		type: "string",
-	},
-	offline: {
-		type: "boolean",
-	},
-	owner: {
-		type: "string",
-	},
-	remote: {
-		type: "boolean",
-	},
-	repository: {
-		type: "string",
-	},
-	"skip-files": {
-		type: "boolean",
-	},
-	"skip-requests": {
-		type: "boolean",
-	},
-	"skip-scripts": {
-		type: "boolean",
-	},
-	version: {
-		type: "boolean",
-	},
-} satisfies ParseArgsOptionsConfig;
+import { cliArgsOptions } from "./cliArgsOptions.js";
 
 export interface RunCLIRawValues {
 	directory?: boolean | string | undefined;

--- a/packages/bingo/src/cli/parsers/getUnknownFlags.test.ts
+++ b/packages/bingo/src/cli/parsers/getUnknownFlags.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { getUnknownFlags } from "./getUnknownFlags.js";
+
+describe(getUnknownFlags, () => {
+	it("returns an empty array when all flags are known CLI flags", () => {
+		const actual = getUnknownFlags({ mode: "setup", offline: true }, {});
+
+		expect(actual).toEqual([]);
+	});
+
+	it("returns an empty array when a flag is a template option", () => {
+		const actual = getUnknownFlags(
+			{ title: "My Title" },
+			{ title: z.string() },
+		);
+
+		expect(actual).toEqual([]);
+	});
+
+	it("returns a suggestion when an unknown flag is close to a known CLI flag", () => {
+		const actual = getUnknownFlags({ "skip-file": true }, {});
+
+		expect(actual).toEqual([{ flag: "skip-file", suggestion: "skip-files" }]);
+	});
+
+	it("returns a suggestion when an unknown flag is close to a template option", () => {
+		const actual = getUnknownFlags(
+			{ titles: "My Title" },
+			{ title: z.string() },
+		);
+
+		expect(actual).toEqual([{ flag: "titles", suggestion: "title" }]);
+	});
+
+	it("returns no suggestion when an unknown flag is not close to any known flag", () => {
+		const actual = getUnknownFlags({ wat: true }, {});
+
+		expect(actual).toEqual([{ flag: "wat", suggestion: undefined }]);
+	});
+
+	it("returns all unknown flags when multiple are provided", () => {
+		const actual = getUnknownFlags({ "skip-file": true, wat: true }, {});
+
+		expect(actual).toEqual([
+			{ flag: "skip-file", suggestion: "skip-files" },
+			{ flag: "wat", suggestion: undefined },
+		]);
+	});
+});

--- a/packages/bingo/src/cli/parsers/getUnknownFlags.test.ts
+++ b/packages/bingo/src/cli/parsers/getUnknownFlags.test.ts
@@ -40,6 +40,15 @@ describe(getUnknownFlags, () => {
 		expect(actual).toEqual([{ flag: "wat", suggestion: undefined }]);
 	});
 
+	it("returns no suggestion when an unknown flag is more than two edits from a known flag", () => {
+		const actual = getUnknownFlags(
+			{ "add-typescript": true },
+			{ "add-javascript": z.boolean() },
+		);
+
+		expect(actual).toEqual([{ flag: "add-typescript", suggestion: undefined }]);
+	});
+
 	it("returns all unknown flags when multiple are provided", () => {
 		const actual = getUnknownFlags({ "skip-file": true, wat: true }, {});
 

--- a/packages/bingo/src/cli/parsers/getUnknownFlags.ts
+++ b/packages/bingo/src/cli/parsers/getUnknownFlags.ts
@@ -1,0 +1,62 @@
+import { AnyShape } from "../../types/shapes.js";
+import { cliArgsOptions } from "../cliArgsOptions.js";
+
+export interface UnknownFlag {
+	flag: string;
+	suggestion?: string;
+}
+
+export function getUnknownFlags(
+	values: object,
+	optionsShape: AnyShape,
+): UnknownFlag[] {
+	const knownFlags = [
+		...Object.keys(cliArgsOptions),
+		...Object.keys(optionsShape),
+	];
+	const knownFlagsSet = new Set(knownFlags);
+
+	return Object.keys(values)
+		.filter((flag) => !knownFlagsSet.has(flag))
+		.map((flag) => ({
+			flag,
+			suggestion: getClosestFlag(flag, knownFlags),
+		}));
+}
+
+function getClosestFlag(flag: string, knownFlags: string[]) {
+	const maximumDistance = Math.max(1, Math.floor(flag.length / 2));
+	let closest: string | undefined;
+	let closestDistance = Infinity;
+
+	for (const knownFlag of knownFlags) {
+		const distance = getEditDistance(flag, knownFlag);
+
+		if (distance <= maximumDistance && distance < closestDistance) {
+			closest = knownFlag;
+			closestDistance = distance;
+		}
+	}
+
+	return closest;
+}
+
+function getEditDistance(left: string, right: string) {
+	let previous = Array.from({ length: right.length + 1 }, (_, i) => i);
+
+	for (let i = 1; i <= left.length; i += 1) {
+		const current = [i];
+
+		for (let j = 1; j <= right.length; j += 1) {
+			current[j] = Math.min(
+				previous[j] + 1,
+				current[j - 1] + 1,
+				previous[j - 1] + (left[i - 1] === right[j - 1] ? 0 : 1),
+			);
+		}
+
+		previous = current;
+	}
+
+	return previous[right.length];
+}

--- a/packages/bingo/src/cli/parsers/getUnknownFlags.ts
+++ b/packages/bingo/src/cli/parsers/getUnknownFlags.ts
@@ -25,7 +25,7 @@ export function getUnknownFlags(
 }
 
 function getClosestFlag(flag: string, knownFlags: string[]) {
-	const maximumDistance = Math.max(1, Math.floor(flag.length / 2));
+	const maximumDistance = Math.min(2, Math.max(1, Math.floor(flag.length / 2)));
 	let closest: string | undefined;
 	let closestDistance = Infinity;
 

--- a/packages/bingo/src/cli/runCLI.ts
+++ b/packages/bingo/src/cli/runCLI.ts
@@ -5,7 +5,9 @@ import { Template } from "../types/templates.js";
 import { ClackDisplay } from "./display/createClackDisplay.js";
 import { logHelpText } from "./loggers/logHelpText.js";
 import { logOutro } from "./loggers/logOutro.js";
+import { logUnknownFlags } from "./loggers/logUnknownFlags.js";
 import { RunCLIRawValues } from "./parseProcessArgv.js";
+import { getUnknownFlags } from "./parsers/getUnknownFlags.js";
 import { readProductionSettings } from "./readProductionSettings.js";
 import { runModeSetup } from "./setup/runModeSetup.js";
 import { CLIStatus } from "./status.js";
@@ -39,6 +41,12 @@ export async function runCLI({
 	template,
 	values,
 }: RunCLISettings) {
+	const unknownFlags = getUnknownFlags(values, template.options);
+	if (unknownFlags.length) {
+		logUnknownFlags(unknownFlags);
+		return { status: CLIStatus.Error };
+	}
+
 	const validatedValues = valuesSchema.parse(values);
 	const productionSettings = await readProductionSettings({
 		from,

--- a/packages/bingo/src/cli/runCli.test.ts
+++ b/packages/bingo/src/cli/runCli.test.ts
@@ -14,6 +14,14 @@ vi.mock("./loggers/logHelpText.js", () => ({
 	},
 }));
 
+const mockLogUnknownFlags = vi.fn();
+
+vi.mock("./loggers/logUnknownFlags.js", () => ({
+	get logUnknownFlags() {
+		return mockLogUnknownFlags;
+	},
+}));
+
 const mockLogOutro = vi.fn();
 
 vi.mock("./loggers/logOutro.js", () => ({
@@ -53,6 +61,22 @@ const template = createTemplate({
 const argv = ["npx", "bingo-example"];
 
 describe("runCli", () => {
+	it("logs unknown flags and errors when an unknown flag is provided", async () => {
+		const actual = await runCLI({
+			argv,
+			display: createClackDisplay(),
+			from: "",
+			template,
+			values: { "skip-file": true } as object,
+		});
+
+		expect(mockLogUnknownFlags).toHaveBeenCalledWith([
+			{ flag: "skip-file", suggestion: "skip-files" },
+		]);
+		expect(actual).toEqual({ status: CLIStatus.Error });
+		expect(mockReadProductionSettings).not.toHaveBeenCalled();
+	});
+
 	it("logs the error when readProductionSettings resolves an error", async () => {
 		const error = new Error("Oh no!");
 		mockReadProductionSettings.mockResolvedValueOnce(error);


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #256
- [x] That issue was marked as [`status: accepting prs`](https://github.com/bingo-js/bingo/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/bingo-js/bingo/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

`runCLI` now compares the parsed flags against the known CLI flags plus the template's own options, and errors out when any flag isn't recognized:

```plaintext
■  Unknown CLI flag: --skip-file
│    Did you mean --skip-files?
│
└  Operation cancelled. Exiting - maybe another time? 👋
```

Suggestions come from an edit distance comparison against the known flags, and are only offered when the typo is reasonably close to one. I implemented a quick one here rather than pulling in a package - I figured it was a "close enough" kind of deal.

The `cliArgsOptions` list moved from `parseProcessArgv.ts` into its own module so it can be used as the source of truth for known flags without pulling in `process.argv` parsing.

💝