### PR TITLE
feat: simplify Handlebars-generated files from arrays to strings when possible

### DIFF
--- a/.changeset/warm-lions-simplify.md
+++ b/.changeset/warm-lions-simplify.md
@@ -1,0 +1,6 @@
+---
+"bingo-handlebars": minor
+"bingo": patch
+---
+
+Simplified Handlebars-generated files from arrays to strings when they carry no metadata.

--- a/packages/bingo-handlebars/src/executeTemplatesRecursive.test.ts
+++ b/packages/bingo-handlebars/src/executeTemplatesRecursive.test.ts
@@ -13,13 +13,28 @@ describe("executeTemplatesRecursive", () => {
 		expect(actual).toBeUndefined();
 	});
 
-	it("executes a template when source is an file with no options", () => {
+	it("returns a string when source is a file with no metadata", () => {
 		const actual = executeTemplatesRecursive(["{{abc}}"], options);
 
-		expect(actual).toEqual(["123"]);
+		expect(actual).toBe("123");
 	});
 
-	it("executes a template when source is an file with options", () => {
+	it("returns a string when source is a file with empty metadata", () => {
+		const actual = executeTemplatesRecursive(["{{abc}}", {}], options);
+
+		expect(actual).toBe("123");
+	});
+
+	it("returns a string when source is a file with executable: false metadata", () => {
+		const actual = executeTemplatesRecursive(
+			["{{abc}}", { executable: false }],
+			options,
+		);
+
+		expect(actual).toBe("123");
+	});
+
+	it("returns a tuple when source is a file with executable: true metadata", () => {
 		const actual = executeTemplatesRecursive(
 			["{{abc}}", { executable: true }],
 			options,

--- a/packages/bingo-handlebars/src/executeTemplatesRecursive.ts
+++ b/packages/bingo-handlebars/src/executeTemplatesRecursive.ts
@@ -1,4 +1,9 @@
-import { CreatedDirectory, CreatedEntry, CreatedFileEntry } from "bingo-fs";
+import {
+	CreatedDirectory,
+	CreatedEntry,
+	CreatedFileEntry,
+	CreatedFileMetadata,
+} from "bingo-fs";
 
 import { executeTemplate } from "./executeTemplate.js";
 
@@ -23,9 +28,10 @@ export function executeTemplatesRecursive(
 	}
 
 	if (Array.isArray(source)) {
-		return source.length === 1
-			? [executeTemplate(source[0], options)]
-			: [executeTemplate(source[0], options), source[1]];
+		const contents = executeTemplate(source[0], options);
+		const metadata = source[1] && simplifyMetadata(source[1]);
+
+		return metadata ? [contents, metadata] : contents;
 	}
 
 	return Object.fromEntries(
@@ -34,4 +40,13 @@ export function executeTemplatesRecursive(
 			executeTemplatesRecursive(value, options),
 		]),
 	);
+}
+
+function simplifyMetadata({
+	executable,
+	...rest
+}: CreatedFileMetadata): CreatedFileMetadata | undefined {
+	const simplified = executable ? { ...rest, executable } : rest;
+
+	return Object.keys(simplified).length ? simplified : undefined;
 }

--- a/packages/bingo-handlebars/src/handlebars.test.ts
+++ b/packages/bingo-handlebars/src/handlebars.test.ts
@@ -32,6 +32,6 @@ describe("handlebars", () => {
 
 		const actual = await handlebars(sourcePath, options);
 
-		expect(actual).toEqual(["123"]);
+		expect(actual).toBe("123");
 	});
 });

--- a/packages/bingo-handlebars/src/handlebarsDirectory.test.ts
+++ b/packages/bingo-handlebars/src/handlebarsDirectory.test.ts
@@ -44,7 +44,7 @@ describe("handlebarsDirectory", () => {
 		const actual = await handlebarsDirectory(sourcePath, options);
 
 		expect(actual).toEqual({
-			index: ["123"],
+			index: "123",
 		});
 	});
 });

--- a/packages/bingo-handlebars/src/handlebarsFile.test.ts
+++ b/packages/bingo-handlebars/src/handlebarsFile.test.ts
@@ -41,6 +41,6 @@ describe("handlebarsFile", () => {
 
 		const actual = await handlebarsFile(sourcePath, options);
 
-		expect(actual).toEqual(["123"]);
+		expect(actual).toBe("123");
 	});
 });

--- a/packages/bingo-handlebars/src/loadHandlebars.test.ts
+++ b/packages/bingo-handlebars/src/loadHandlebars.test.ts
@@ -42,6 +42,6 @@ describe("loadHandlebars", () => {
 
 		const actual = handlebars("file.txt.hbs", { def: 456 });
 
-		expect(actual).toEqual(["123456"]);
+		expect(actual).toBe("123456");
 	});
 });

--- a/packages/bingo/src/mergers/mergeFileEntries.test.ts
+++ b/packages/bingo/src/mergers/mergeFileEntries.test.ts
@@ -25,6 +25,9 @@ describe("mergeFileEntries", () => {
 		[["a", {}], "a", "a"],
 		[["a", {}], ["a", {}], "a"],
 		[["a", {}], ["a", {}], "a"],
+		["a", ["a", { executable: false }], "a"],
+		[["a", { executable: false }], "a", "a"],
+		[["a"], ["a", { executable: false }], "a"],
 		[
 			["a", { executable: true }],
 			["a", { executable: true }],

--- a/packages/bingo/src/mergers/mergeFileEntries.ts
+++ b/packages/bingo/src/mergers/mergeFileEntries.ts
@@ -22,15 +22,16 @@ export function mergeFileEntries(
 		throw new Error(`Conflicting created files at path: '${path.join("/")}'.`);
 	}
 
-	if (firstSettings?.executable !== secondSettings?.executable) {
+	const firstExecutable = !!firstSettings?.executable;
+	const secondExecutable = !!secondSettings?.executable;
+
+	if (firstExecutable !== secondExecutable) {
 		throw new Error(
 			`Conflicting created file executable at path: '${path.join("/")}'.`,
 		);
 	}
 
-	const executable = firstSettings?.executable ?? secondSettings?.executable;
-
-	return executable ? [firstFile, { executable }] : firstFile;
+	return firstExecutable ? [firstFile, { executable: true }] : firstFile;
 }
 
 function isBlankEntry(entry: CreatedEntry | undefined) {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #267
- [x] That issue was marked as [`status: accepting prs`](https://github.com/bingo-js/bingo/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/bingo-js/bingo/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

`executeTemplatesRecursive` now drops file metadata that carries no information:

1. `executable: false` is omitted
2. If nothing is left in the metadata, the file is returned as a plain `string` instead of a `[string, CreatedFileMetadata]` tuple

So a non-executable Handlebars file now snapshots as `".gitignore": "/node_modules\n"` rather than `".gitignore": ["/node_modules\n", { "executable": false }]`.

💝