### PR TITLE
fix: make StratumTemplateOptionsShape a type so Stratum templates infer as Templates

### DIFF
--- a/.changeset/quiet-pandas-infer.md
+++ b/.changeset/quiet-pandas-infer.md
@@ -1,0 +1,5 @@
+---
+"bingo-stratum": patch
+---
+
+Made `StratumTemplateOptionsShape` a type so Stratum templates infer as `Template`s.

--- a/packages/bingo-stratum/src/creators/createStratumTemplate.test.ts
+++ b/packages/bingo-stratum/src/creators/createStratumTemplate.test.ts
@@ -1,4 +1,5 @@
 import { allPropertiesLazy } from "all-properties-lazy";
+import { produceTemplate } from "bingo";
 import chalk from "chalk";
 import { describe, expect, it, vi } from "vitest";
 import { z } from "zod";
@@ -27,6 +28,27 @@ const mockLog = vi.fn();
 const mockOptions = { name: "Test Name" };
 
 describe("createStratumTemplate", () => {
+	it("can be passed to APIs taking in a generic Template", async () => {
+		const template = base.createStratumTemplate({
+			presets: [
+				base.createPreset({
+					about: { name: "Example" },
+					blocks: [
+						base.createBlock({
+							produce: () => ({ files: { "example.txt": "example" } }),
+						}),
+					],
+				}),
+			],
+		});
+
+		const actual = await produceTemplate(template, {
+			options: { ...mockOptions, preset: "example" },
+		});
+
+		expect(actual).toEqual({ files: { "example.txt": "example" } });
+	});
+
 	describe("blocks", () => {
 		it("adds extra blocks alongside those from presets when the template definition includes them", () => {
 			const blockInsidePreset = base.createBlock({

--- a/packages/bingo-stratum/src/types/templates.ts
+++ b/packages/bingo-stratum/src/types/templates.ts
@@ -103,12 +103,15 @@ export interface StratumTemplateOptions {
 /**
  * The minimum options schemas all Stratum Templates share.
  */
-export interface StratumTemplateOptionsShape {
+// Interfaces don't receive an implicit index signature, so intersecting one
+// with a Template's options shape stops it being assignable to z.ZodRawShape.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export type StratumTemplateOptionsShape = {
 	/**
 	 * Union of Preset names available to choose from.
 	 */
 	preset: z.ZodDefault<z.ZodUnion<ZodPresetNameLiterals>>;
-}
+};
 
 /**
  * Union of at least two literal Preset names available to choose from.


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #272
- [x] That issue was marked as [`status: accepting prs`](https://github.com/bingo-js/bingo/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/bingo-js/bingo/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

`StratumTemplate<OptionsShape>` extends `Template<OptionsShape & StratumTemplateOptionsShape, ...>`. `StratumTemplateOptionsShape` was an `interface`, and TypeScript only gives *implicit index signatures* to type aliases. That made the intersection unassignable to `z.ZodRawShape`, so inference for `OptionsShape` failed on any generic API taking a `Template<OptionsShape, Refinements>` (`testTemplate`, `produceTemplate`, …) and fell back to the constraint, producing the confusing `createConfig` mismatch in the issue.

Switching that one interface to a type alias fixes inference. The added `createStratumTemplate` test passes a Stratum template to `produceTemplate`, which fails to compile without the change.

💝