### PR TITLE
feat: add a Zod description of FetchInit for inputFromFetch

### DIFF
--- a/.changeset/plain-inputs-describe.md
+++ b/.changeset/plain-inputs-describe.md
@@ -1,0 +1,5 @@
+---
+"input-from-fetch": minor
+---
+
+Added a Zod description of `FetchInit` for `inputFromFetch`.

--- a/packages/input-from-fetch/README.md
+++ b/packages/input-from-fetch/README.md
@@ -24,7 +24,7 @@ await take(inputFromScript, { command: "https://example.com" });
 `inputFromFetch` defines two parameters:
 
 - `resource` _(required)_: the `string` or [`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request) to be passed to [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API)
-- `options` _(optional)_: the [`RequestInit`](https://developer.mozilla.org/en-US/docs/Web/API/RequestInit) object to be passed to [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API)
+- `init` _(optional)_: the [`RequestInit`](https://developer.mozilla.org/en-US/docs/Web/API/RequestInit) object to be passed to [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API)
 
 It sends a request to the `resource` with [Input Context `fetch`](https://create.bingo/build/details/contexts#input-fetchers) and returns either:
 

--- a/packages/input-from-fetch/src/fetchInit.ts
+++ b/packages/input-from-fetch/src/fetchInit.ts
@@ -1,0 +1,158 @@
+import { z } from "zod";
+
+/**
+ * Zod description of the `RequestInit` options object passed to `fetch`.
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/RequestInit}
+ */
+export const fetchInit = z.object({
+	/**
+	 * Indicates that the request's response should be able to register a
+	 * JavaScript-based attribution source or trigger.
+	 * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/RequestInit#attributionreporting}
+	 */
+	attributionReporting: z
+		.object({
+			/**
+			 * Whether the response is eligible to register an attribution source.
+			 * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/RequestInit#eventsourceeligible}
+			 */
+			eventSourceEligible: z.boolean().optional(),
+
+			/**
+			 * Whether the response is eligible to register an attribution trigger.
+			 * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/RequestInit#triggereligible}
+			 */
+			triggerEligible: z.boolean().optional(),
+		})
+		.optional(),
+
+	/**
+	 * Body to send with the request.
+	 * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/RequestInit#body}
+	 */
+	body: z
+		.union([
+			z.string(),
+			z.instanceof(Blob),
+			z.instanceof(FormData),
+			z.instanceof(URLSearchParams),
+			z.instanceof(ArrayBuffer),
+			z.instanceof(ReadableStream),
+			z.custom<Extract<BodyInit, ArrayBufferView>>((value) =>
+				ArrayBuffer.isView(value),
+			),
+		])
+		.optional(),
+
+	/**
+	 * Whether the selected topics for the request's URL should be sent in a
+	 * `Sec-Browsing-Topics` header.
+	 * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/RequestInit#browsingtopics}
+	 */
+	browsingTopics: z.boolean().optional(),
+
+	/**
+	 * How the request will interact with the browser's HTTP cache.
+	 * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/RequestInit#cache}
+	 */
+	cache: z
+		.enum([
+			"default",
+			"no-store",
+			"reload",
+			"no-cache",
+			"force-cache",
+			"only-if-cached",
+		])
+		.optional(),
+
+	/**
+	 * Whether the user agent should send or receive cookies for the request.
+	 * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/RequestInit#credentials}
+	 */
+	credentials: z.enum(["omit", "same-origin", "include"]).optional(),
+
+	/**
+	 * Headers to add to the request.
+	 * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/RequestInit#headers}
+	 */
+	headers: z
+		.union([
+			z.instanceof(Headers),
+			z.record(z.string()),
+			z.array(z.tuple([z.string(), z.string()])),
+		])
+		.optional(),
+
+	/**
+	 * Cryptographic hash used to verify the integrity of the fetched resource.
+	 * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/RequestInit#integrity}
+	 */
+	integrity: z.string().optional(),
+
+	/**
+	 * Whether to allow the request to outlive the page.
+	 * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/RequestInit#keepalive}
+	 */
+	keepalive: z.boolean().optional(),
+
+	/**
+	 * Request method.
+	 * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/RequestInit#method}
+	 */
+	method: z.string().optional(),
+
+	/**
+	 * Mode to use for the request.
+	 * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/RequestInit#mode}
+	 */
+	mode: z.enum(["same-origin", "no-cors", "cors", "navigate"]).optional(),
+
+	/**
+	 * Priority of the request relative to other requests of the same type.
+	 * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/RequestInit#priority}
+	 */
+	priority: z.enum(["high", "low", "auto"]).optional(),
+
+	/**
+	 * How to handle a redirect response.
+	 * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/RequestInit#redirect}
+	 */
+	redirect: z.enum(["follow", "error", "manual"]).optional(),
+
+	/**
+	 * Referrer of the request.
+	 * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/RequestInit#referrer}
+	 */
+	referrer: z.string().optional(),
+
+	/**
+	 * Referrer policy to use for the request.
+	 * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/RequestInit#referrerpolicy}
+	 */
+	referrerPolicy: z
+		.enum([
+			"",
+			"no-referrer",
+			"no-referrer-when-downgrade",
+			"same-origin",
+			"origin",
+			"strict-origin",
+			"origin-when-cross-origin",
+			"strict-origin-when-cross-origin",
+			"unsafe-url",
+		])
+		.optional(),
+
+	/**
+	 * Signal that can be used to abort the request.
+	 * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/RequestInit#signal}
+	 */
+	signal: z.instanceof(AbortSignal).nullish(),
+
+	/**
+	 * Can only be `null`, used to disassociate the request from any window.
+	 * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/RequestInit#window}
+	 */
+	window: z.null().optional(),
+});

--- a/packages/input-from-fetch/src/fetchInit.ts
+++ b/packages/input-from-fetch/src/fetchInit.ts
@@ -42,7 +42,7 @@ export const fetchInit = z.object({
 				ArrayBuffer.isView(value),
 			),
 		])
-		.optional(),
+		.nullish(),
 
 	/**
 	 * Whether the selected topics for the request's URL should be sent in a
@@ -73,13 +73,20 @@ export const fetchInit = z.object({
 	credentials: z.enum(["omit", "same-origin", "include"]).optional(),
 
 	/**
+	 * Duplex mode of the request. Must be present when `body` is a
+	 * `ReadableStream`.
+	 * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/RequestInit#duplex}
+	 */
+	duplex: z.literal("half").optional(),
+
+	/**
 	 * Headers to add to the request.
 	 * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/RequestInit#headers}
 	 */
 	headers: z
 		.union([
 			z.instanceof(Headers),
-			z.record(z.string()),
+			z.record(z.string(), z.string()),
 			z.array(z.tuple([z.string(), z.string()])),
 		])
 		.optional(),

--- a/packages/input-from-fetch/src/index.test.ts
+++ b/packages/input-from-fetch/src/index.test.ts
@@ -1,4 +1,8 @@
-import { createMockFetchers, testInput } from "bingo-testers";
+import {
+	createMockFetchers,
+	createMockSystems,
+	testInput,
+} from "bingo-testers";
 import { describe, expect, it, vi } from "vitest";
 
 import { inputFromFetch } from "./index.js";
@@ -16,6 +20,48 @@ describe("inputFromFetch", () => {
 
 		expect(actual).toBe(expected);
 		expect(fetch).toHaveBeenCalledWith(resource, undefined);
+	});
+
+	it("returns undefined when running offline", async () => {
+		const fetch = vi.fn();
+		const { system, take } = createMockSystems({
+			fetchers: createMockFetchers(fetch),
+		});
+
+		const actual = await inputFromFetch({
+			...system,
+			args: { resource: "https://example.com" },
+			offline: true,
+			take,
+		});
+
+		expect(actual).toBeUndefined();
+		expect(fetch).not.toHaveBeenCalled();
+	});
+
+	it("returns the error when the network request rejects", async () => {
+		const expected = new Error("Oh no!");
+		const fetch = vi.fn().mockRejectedValue(expected);
+
+		const actual = await testInput(inputFromFetch, {
+			args: { resource: "https://example.com" },
+			fetchers: createMockFetchers(fetch),
+		});
+
+		expect(actual).toBe(expected);
+	});
+
+	it("passes a typed array body through to fetch unchanged", async () => {
+		const resource = "https://example.com";
+		const init = { body: new Uint8Array([1, 2, 3]) };
+		const fetch = vi.fn().mockResolvedValue({});
+
+		await testInput(inputFromFetch, {
+			args: { init, resource },
+			fetchers: createMockFetchers(fetch),
+		});
+
+		expect(fetch).toHaveBeenCalledWith(resource, init);
 	});
 
 	it("passes class-based init values through to fetch unchanged", async () => {

--- a/packages/input-from-fetch/src/index.test.ts
+++ b/packages/input-from-fetch/src/index.test.ts
@@ -17,4 +17,36 @@ describe("inputFromFetch", () => {
 		expect(actual).toBe(expected);
 		expect(fetch).toHaveBeenCalledWith(resource, undefined);
 	});
+
+	it("passes class-based init values through to fetch unchanged", async () => {
+		const resource = "https://example.com";
+		const init = {
+			body: new URLSearchParams({ key: "value" }),
+			headers: new Headers({ "content-type": "text/plain" }),
+			signal: AbortSignal.timeout(1000),
+		};
+		const fetch = vi.fn().mockResolvedValue({});
+
+		await testInput(inputFromFetch, {
+			args: { init, resource },
+			fetchers: createMockFetchers(fetch),
+		});
+
+		expect(fetch).toHaveBeenCalledWith(resource, init);
+	});
+
+	it("passes init to fetch when provided", async () => {
+		const resource = "https://example.com";
+		const init = { method: "POST" };
+		const expected = { stdout: "123" };
+		const fetch = vi.fn().mockResolvedValue(expected);
+
+		const actual = await testInput(inputFromFetch, {
+			args: { init, resource },
+			fetchers: createMockFetchers(fetch),
+		});
+
+		expect(actual).toBe(expected);
+		expect(fetch).toHaveBeenCalledWith(resource, init);
+	});
 });

--- a/packages/input-from-fetch/src/index.test.ts
+++ b/packages/input-from-fetch/src/index.test.ts
@@ -64,6 +64,36 @@ describe("inputFromFetch", () => {
 		expect(fetch).toHaveBeenCalledWith(resource, init);
 	});
 
+	it("passes a stream body and duplex through to fetch unchanged", async () => {
+		const resource = "https://example.com";
+		const init = {
+			body: new ReadableStream(),
+			duplex: "half" as const,
+			method: "POST",
+		};
+		const fetch = vi.fn().mockResolvedValue({});
+
+		await testInput(inputFromFetch, {
+			args: { init, resource },
+			fetchers: createMockFetchers(fetch),
+		});
+
+		expect(fetch).toHaveBeenCalledWith(resource, init);
+	});
+
+	it("passes a null body through to fetch unchanged", async () => {
+		const resource = "https://example.com";
+		const init = { body: null };
+		const fetch = vi.fn().mockResolvedValue({});
+
+		await testInput(inputFromFetch, {
+			args: { init, resource },
+			fetchers: createMockFetchers(fetch),
+		});
+
+		expect(fetch).toHaveBeenCalledWith(resource, init);
+	});
+
 	it("passes class-based init values through to fetch unchanged", async () => {
 		const resource = "https://example.com";
 		const init = {

--- a/packages/input-from-fetch/src/index.ts
+++ b/packages/input-from-fetch/src/index.ts
@@ -1,14 +1,11 @@
 import { createInput } from "bingo";
 import { z } from "zod";
 
+import { fetchInit } from "./fetchInit.js";
+
 export const inputFromFetch = createInput({
 	args: {
-		options: z
-			.object({
-				// TODO: fill out!
-				// https://github.com/bingo-js/bingo/issues/282
-			})
-			.optional(),
+		init: fetchInit.optional(),
 		resource: z.string(),
 	},
 	async produce({ args, fetchers, offline }) {
@@ -17,7 +14,7 @@ export const inputFromFetch = createInput({
 		}
 
 		try {
-			return await fetchers.fetch(args.resource, args.options);
+			return await fetchers.fetch(args.resource, args.init);
 		} catch (error) {
 			return error as Error;
 		}


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #282
- [x] That issue was marked as [`status: accepting prs`](https://github.com/bingo-js/bingo/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/bingo-js/bingo/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Fills out `inputFromFetch`'s previously empty second arg with a full Zod description of [`RequestInit`](https://developer.mozilla.org/en-US/docs/Web/API/RequestInit), and renames it from `options` to `init` to match the `fetch` API.

Every property has a doc comment with an MDN `@see` link. Class-valued properties (`Headers`, `AbortSignal`, `FormData`, …) use `z.instanceof` so they pass through arg parsing unchanged, which the added tests cover.

> Note: renaming `options` to `init` is a breaking change for anyone passing that arg today.

💝