### PR TITLE
fix: type CreatedBlockAddons with object instead of any

### DIFF
--- a/.changeset/tidy-addons-typed.md
+++ b/.changeset/tidy-addons-typed.md
@@ -1,0 +1,5 @@
+---
+"bingo-stratum": patch
+---
+
+Typed `CreatedBlockAddons` with `object` instead of `any`.

--- a/packages/bingo-stratum/src/creators/createBlock.test.ts
+++ b/packages/bingo-stratum/src/creators/createBlock.test.ts
@@ -59,5 +59,34 @@ describe("createBlock", () => {
 				},
 			});
 		});
+
+		it("produces Addons for another Block", () => {
+			const blockReceiving = createBlock<
+				{ names: z.ZodDefault<z.ZodArray<z.ZodString>> },
+				{ name: string }
+			>({
+				addons: {
+					names: z.array(z.string()).default([]),
+				},
+				produce() {
+					return {};
+				},
+			});
+			const blockProviding = createBlock<{ name: string }>({
+				produce() {
+					return {
+						addons: [blockReceiving({ names: ["def"] })],
+					};
+				},
+			});
+
+			const production = blockProviding.produce({
+				options: { name: "abc", preset: "test" },
+			});
+
+			expect(production).toEqual({
+				addons: [{ addons: { names: ["def"] }, block: blockReceiving }],
+			});
+		});
 	});
 });

--- a/packages/bingo-stratum/src/producers/applyBlockRefinements.test.ts
+++ b/packages/bingo-stratum/src/producers/applyBlockRefinements.test.ts
@@ -25,6 +25,14 @@ const blockC = base.createBlock({
 	produce: vi.fn(),
 });
 
+const blockWithAddons = base.createBlock({
+	about: { name: "With Addons" },
+	addons: {
+		names: z.array(z.string()).default([]),
+	},
+	produce: vi.fn(),
+});
+
 const blocksAvailable = [blockA, blockB, blockC];
 
 describe("applyBlockRefinements", () => {
@@ -166,6 +174,22 @@ describe("applyBlockRefinements", () => {
 		);
 
 		expect(actual).toEqual([blockA, blockC]);
+	});
+
+	it("returns added blocks when an added Block has Addons", () => {
+		const initial = [blockA];
+
+		const actual = applyBlockRefinements(
+			blocksAvailable,
+			initial,
+			{ value: "" },
+			{
+				add: [blockWithAddons],
+				exclude: [],
+			},
+		);
+
+		expect(actual).toEqual([blockA, blockWithAddons]);
 	});
 
 	it("returns modified blocks when both exclusion options and refinements are provided", () => {

--- a/packages/bingo-stratum/src/types/blocks.ts
+++ b/packages/bingo-stratum/src/types/blocks.ts
@@ -251,21 +251,27 @@ export interface BlockWithAddons<
 	 * Generates the creations describing a portion of a repository.
 	 * @see {@link https://www.create.bingo/engines/stratum/apis/create-base#createblock-produce}
 	 */
-	produce: BlockProducerWithAddons<Addons, Options>;
+	produce(
+		context: BlockContextWithOptionalAddons<Addons, Options>,
+	): Partial<BlockCreation<Options>>;
 
 	/**
 	 * Augments a Block creation with additional creations for setup mode.
 	 * @template Options Options values as described by the Base's options schema.
 	 * @see {@link https://www.create.bingo/engines/stratum/apis/create-base#createblock-setup}
 	 */
-	setup?: BlockAugmentWithAddons<Addons, Options>;
+	setup?(
+		context: BlockContextWithAddons<Addons, Options>,
+	): Partial<BlockCreation<Options>>;
 
 	/**
 	 * Augments a Block creation with additional creations for transition mode.
 	 * @template Options Options values as described by the Base's options schema.
 	 * @see {@link https://www.create.bingo/engines/stratum/apis/create-base#createblock-transition}
 	 */
-	transition?: BlockAugmentWithAddons<Addons, Options>;
+	transition?(
+		context: BlockContextWithAddons<Addons, Options>,
+	): Partial<BlockCreation<Options>>;
 
 	/**
 	 * Creates a description of Addons to provide for the Block.

--- a/packages/bingo-stratum/src/types/creations.ts
+++ b/packages/bingo-stratum/src/types/creations.ts
@@ -3,11 +3,7 @@ import { Creation } from "bingo";
 import { BlockWithAddons } from "./blocks.js";
 
 export interface BlockCreation<Options extends object> extends Creation {
-	// TODO: Figure out how to replace this with ... never? object?
-	// Note it needs to pass tsc both in this repo and in create-typescript-app.
-	// https://github.com/bingo-js/bingo/issues/283
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	addons: CreatedBlockAddons<any, Options>[];
+	addons: CreatedBlockAddons<object, Options>[];
 }
 
 /**

--- a/packages/bingo-stratum/src/types/refinements.ts
+++ b/packages/bingo-stratum/src/types/refinements.ts
@@ -20,10 +20,7 @@ export interface StratumRefinements<Options extends object = object> {
 	/**
 	 * Any extra addon values to merge in and pass to blocks.
 	 */
-	// TODO: Get this to work with object or never...
-	// https://github.com/bingo-js/bingo/issues/283
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	addons?: CreatedBlockAddons<any, Options>[];
+	addons?: CreatedBlockAddons<object, Options>[];
 
 	/**
 	 * Blocks to add and/or exclude from production.


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #283
- [x] That issue was marked as [`status: accepting prs`](https://github.com/bingo-js/bingo/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/bingo-js/bingo/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

`BlockCreation["addons"]` and `StratumRefinements["addons"]` are now `CreatedBlockAddons<object, Options>[]` instead of `CreatedBlockAddons<any, Options>[]`.

`object` didn't work before because `BlockWithAddons<Addons, Options>` is *invariant* in `Addons`: it appears covariantly (`intake`'s return, the call signature's return) and contravariantly (the `context.addons` parameter of `produce`/`setup`/`transition`). The covariant side is happy with `object`; the contravariant side is what produced the wall of errors in create-typescript-app.

This declares `produce`, `setup`, and `transition` on `BlockWithAddons` with **method syntax**, which TypeScript checks bivariantly, so a `BlockWithAddons<SpecificAddons, Options>` is assignable to `BlockWithAddons<object, Options>` and heterogeneous addons can share one array.

The trade-off is that those three members are now bivariant rather than strictly contravariant. The public `BlockProducerWithAddons` / `BlockAugmentWithAddons` aliases are left exported and unchanged.

### Verification

Nothing in this repo covered the pattern that broke create-typescript-app, so `createBlock.test.ts` gains a test where one Block's `produce` returns addons for another Block. It fails to compile without the `BlockWithAddons` change.

I also type-checked create-typescript-app's `main` against these packages (published deps, with the built `lib` folders swapped in): 0 errors, versus 44 errors with `object` alone.

💝