### PR TITLE
chore: pass request.parameters into octokit.request without an any assertion

### DIFF
--- a/.changeset/brave-octokit-typed.md
+++ b/.changeset/brave-octokit-typed.md
@@ -1,5 +1,0 @@
----
-"bingo": patch
----
-
-Passed `request.parameters` into `octokit.request` without an `any` cast.

--- a/.changeset/brave-octokit-typed.md
+++ b/.changeset/brave-octokit-typed.md
@@ -1,0 +1,5 @@
+---
+"bingo": patch
+---
+
+Passed `request.parameters` into `octokit.request` without an `any` cast.

--- a/packages/bingo/src/runners/getRequestSender.ts
+++ b/packages/bingo/src/runners/getRequestSender.ts
@@ -25,13 +25,7 @@ export function getRequestSender(
 				octokit && {
 					id: request.id ?? request.endpoint,
 					send: async () => {
-						await octokit.request(
-							request.endpoint,
-							// TODO: I have no idea how to get this to type-check without the any.
-							// https://github.com/bingo-js/bingo/issues/286
-							// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
-							request.parameters as any,
-						);
+						await octokit.request(request.endpoint, request.parameters);
 					},
 				}
 			);


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #286
- [x] That issue was marked as [`status: accepting prs`](https://github.com/bingo-js/bingo/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/bingo-js/bingo/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This used to give a type error. It doesn't anymore. Yay!

💝