### PR TITLE
fix: assert every CLI option is printed in --help, and correct some

### DIFF
--- a/packages/bingo/src/cli/loggers/logHelpText.test.ts
+++ b/packages/bingo/src/cli/loggers/logHelpText.test.ts
@@ -16,8 +16,6 @@ vi.mock("@clack/prompts", () => ({
 	},
 }));
 
-// node:util's parseArgs can only describe these as "string", so help text is
-// allowed to print a narrower type for them.
 const narrowedTypes = new Map([["mode", '"setup" | "transition"']]);
 
 describe("logHelpText", () => {

--- a/packages/bingo/src/cli/loggers/logHelpText.test.ts
+++ b/packages/bingo/src/cli/loggers/logHelpText.test.ts
@@ -16,8 +16,12 @@ vi.mock("@clack/prompts", () => ({
 	},
 }));
 
+// node:util's parseArgs can only describe these as "string", so help text is
+// allowed to print a narrower type for them.
+const narrowedTypes = new Map([["mode", '"setup" | "transition"']]);
+
 describe("logHelpText", () => {
-	it("prints every CLI flag", () => {
+	it("prints every CLI flag with its parsed type", () => {
 		logHelpText(
 			"setup",
 			"./template.js",
@@ -27,9 +31,11 @@ describe("logHelpText", () => {
 		);
 
 		const [[message]] = mockLog.message.mock.calls;
-		const missing = Object.keys(cliArgsOptions).filter(
-			(flag) => !message.includes(`--${flag} (`),
-		);
+		const missing = Object.entries(cliArgsOptions)
+			.map(
+				([flag, { type }]) => `--${flag} (${narrowedTypes.get(flag) ?? type})`,
+			)
+			.filter((expected) => !message.includes(expected));
 
 		expect(missing).toEqual([]);
 	});

--- a/packages/bingo/src/cli/loggers/logHelpText.test.ts
+++ b/packages/bingo/src/cli/loggers/logHelpText.test.ts
@@ -1,12 +1,13 @@
-import { describe, expect, test, vi } from "vitest";
+import { describe, expect, it, test, vi } from "vitest";
 import { z } from "zod";
 
 import { createTemplate } from "../../creators/createTemplate.js";
+import { cliArgsOptions } from "../parseProcessArgv.js";
 import { logHelpText } from "./logHelpText.js";
 
 const mockLog = {
 	info: vi.fn(),
-	message: vi.fn(),
+	message: vi.fn<(message: string) => void>(),
 };
 
 vi.mock("@clack/prompts", () => ({
@@ -16,6 +17,23 @@ vi.mock("@clack/prompts", () => ({
 }));
 
 describe("logHelpText", () => {
+	it("prints every CLI flag", () => {
+		logHelpText(
+			"setup",
+			"./template.js",
+			createTemplate({
+				produce: vi.fn(),
+			}),
+		);
+
+		const [[message]] = mockLog.message.mock.calls;
+		const missing = Object.keys(cliArgsOptions).filter(
+			(flag) => !message.includes(`--${flag} (`),
+		);
+
+		expect(missing).toEqual([]);
+	});
+
 	test("anonymous template with no options", () => {
 		logHelpText(
 			"setup",
@@ -40,7 +58,7 @@ describe("logHelpText", () => {
 			  --directory (string): What local directory path to run under
 			      npx ./template.js --directory my-fancy-project
 
-			  --help (string): Prints help text.
+			  --help (boolean): Prints help text.
 			      npx ./template.js --help
 
 			  --mode ("setup" | "transition"): Which mode to run in.
@@ -50,14 +68,23 @@ describe("logHelpText", () => {
 			  --offline (boolean): Whether to run in an "offline" mode that skips network requests.
 			      npx ./template.js --offline
 
+			  --owner (string): What GitHub organization or user the repository will be under.
+			      npx ./template.js --owner my-org
+
 			  --remote (boolean): Whether to create a remote repository on GitHub if one does not already exist.
 			      npx ./template.js --remote
+
+			  --repository (string): What the repository will be named.
+			      npx ./template.js --repository my-fancy-project
 
 			  --skip-files (boolean): Whether to skip creating files on disk.
 			      npx ./template.js --skip-files
 
 			  --skip-requests (boolean): Whether to skip sending network requests as specified by templates.
 			      npx ./template.js --skip-requests
+
+			  --skip-scripts (boolean): Whether to skip running local scripts as specified by templates.
+			      npx ./template.js --skip-scripts
 
 			  --version (boolean): Prints package versions.
 			      npx ./template.js --version
@@ -100,7 +127,7 @@ describe("logHelpText", () => {
 			  --directory (string): What local directory path to run under
 			      npx ./template.js --directory my-fancy-project
 
-			  --help (string): Prints help text.
+			  --help (boolean): Prints help text.
 			      npx ./template.js --help
 
 			  --mode ("setup" | "transition"): Which mode to run in.
@@ -110,14 +137,23 @@ describe("logHelpText", () => {
 			  --offline (boolean): Whether to run in an "offline" mode that skips network requests.
 			      npx ./template.js --offline
 
+			  --owner (string): What GitHub organization or user the repository will be under.
+			      npx ./template.js --owner my-org
+
 			  --remote (boolean): Whether to create a remote repository on GitHub if one does not already exist.
 			      npx ./template.js --remote
+
+			  --repository (string): What the repository will be named.
+			      npx ./template.js --repository my-fancy-project
 
 			  --skip-files (boolean): Whether to skip creating files on disk.
 			      npx ./template.js --skip-files
 
 			  --skip-requests (boolean): Whether to skip sending network requests as specified by templates.
 			      npx ./template.js --skip-requests
+
+			  --skip-scripts (boolean): Whether to skip running local scripts as specified by templates.
+			      npx ./template.js --skip-scripts
 
 			  --version (boolean): Prints package versions.
 			      npx ./template.js --version

--- a/packages/bingo/src/cli/loggers/logHelpText.ts
+++ b/packages/bingo/src/cli/loggers/logHelpText.ts
@@ -37,7 +37,7 @@ export function logHelpText<OptionsShape extends AnyShape, Refinements>(
 			examples: ["--help"],
 			flag: "--help",
 			text: "Prints help text.",
-			type: "string",
+			type: "boolean",
 		},
 		{
 			examples: ["--mode setup", "--mode transition"],
@@ -52,10 +52,22 @@ export function logHelpText<OptionsShape extends AnyShape, Refinements>(
 			type: "boolean",
 		},
 		{
+			examples: ["--owner my-org"],
+			flag: "--owner",
+			text: "What GitHub organization or user the repository will be under.",
+			type: "string",
+		},
+		{
 			examples: ["--remote"],
 			flag: "--remote",
 			text: "Whether to create a remote repository on GitHub if one does not already exist.",
 			type: "boolean",
+		},
+		{
+			examples: ["--repository my-fancy-project"],
+			flag: "--repository",
+			text: "What the repository will be named.",
+			type: "string",
 		},
 		{
 			examples: ["--skip-files"],
@@ -67,6 +79,12 @@ export function logHelpText<OptionsShape extends AnyShape, Refinements>(
 			examples: ["--skip-requests"],
 			flag: "--skip-requests",
 			text: "Whether to skip sending network requests as specified by templates.",
+			type: "boolean",
+		},
+		{
+			examples: ["--skip-scripts"],
+			flag: "--skip-scripts",
+			text: "Whether to skip running local scripts as specified by templates.",
 			type: "boolean",
 		},
 		{

--- a/packages/bingo/src/cli/parseProcessArgv.ts
+++ b/packages/bingo/src/cli/parseProcessArgv.ts
@@ -47,6 +47,7 @@ export interface RunCLIRawValues {
 	mode?: boolean | string | undefined;
 	offline?: boolean | string | undefined;
 	owner?: boolean | string | undefined;
+	remote?: boolean | string | undefined;
 	repository?: boolean | string | undefined;
 	"skip-files"?: boolean | string | undefined;
 	"skip-requests"?: boolean | string | undefined;

--- a/packages/bingo/src/cli/parseProcessArgv.ts
+++ b/packages/bingo/src/cli/parseProcessArgv.ts
@@ -5,7 +5,7 @@ import { parseArgs, ParseArgsConfig } from "node:util";
 
 type ParseArgsOptionsConfig = NonNullable<ParseArgsConfig["options"]>;
 
-const cliArgsOptions = {
+export const cliArgsOptions = {
 	directory: {
 		type: "string",
 	},

--- a/packages/site/src/content/docs/cli.mdx
+++ b/packages/site/src/content/docs/cli.mdx
@@ -82,6 +82,23 @@ For example, specifying creating a new repository offline with [`create-typescri
 If you are finding your template still sends requests with `--offline`, file a bug on the template.
 :::
 
+### `--owner`
+
+> Type: `string`
+
+What GitHub organization or user the repository will be under.
+
+This is used as the owner of the repository created by [`--remote`](#--remote).
+If not provided, Bingo will infer it from the GitHub CLI's configured user, then prompt for it if the template defines an `owner` option.
+
+For example, creating a new repository under a `my-organization` organization:
+
+<PackageManagers
+	args="--owner my-organization --remote"
+	pkg="create-typescript-app"
+	type="dlx"
+/>
+
 ### `--remote`
 
 > Type: `boolean`
@@ -96,6 +113,23 @@ When enabled, Bingo will:
 - Apply any network requests specified by the template to the remote repository
 
 When disabled, Bingo will not create a remote repository and will skip requests ([`--skip-requests`](#--skip-requests) will default to `true`).
+
+### `--repository`
+
+> Type: `string`
+
+What the repository will be named.
+
+Defaults to the name of the [`--directory`](#--directory) being run under.
+Providing `--repository` without [`--directory`](#--directory) will also use it as the directory name.
+
+For example, creating a new repository whose name differs from its local directory:
+
+<PackageManagers
+	args="--directory my-local-directory --repository my-fancy-project"
+	pkg="create-typescript-app"
+	type="dlx"
+/>
 
 ### `--skip-files`
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #398
- [x] That issue was marked as [`status: accepting prs`](https://github.com/bingo-js/bingo/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/bingo-js/bingo/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds a `logHelpText` test that walks `cliArgsOptions` — the list `parseProcessArgv` actually parses — and fails with the names of any flags missing from the printed help text.

It caught three: `--owner`, `--repository`, and `--skip-scripts`, so they're added to the help options. It also fixes `--help`'s listed type, which said `string`.

Also fixed up the website's [CLI page](https://www.create.bingo/cli) missing sections for `--owner` and `--repository`.

💝