### PR TITLE
feat: migrate to Zod v4

### DIFF
--- a/packages/bingo-stratum-testers/package.json
+++ b/packages/bingo-stratum-testers/package.json
@@ -26,7 +26,7 @@
 		"bingo-fs": "workspace:^",
 		"bingo-stratum": "workspace:^",
 		"bingo-systems": "workspace:^",
-		"zod": "3.24.2"
+		"zod": "4.4.3"
 	},
 	"peerDependencies": {
 		"bingo": "workspace:^",

--- a/packages/bingo-stratum/package.json
+++ b/packages/bingo-stratum/package.json
@@ -35,13 +35,13 @@
 		"bingo": "workspace:^",
 		"bingo-fs": "workspace:^",
 		"bingo-systems": "workspace:^",
-		"zod": "^3.24.2"
+		"zod": "^4.4.3"
 	},
 	"peerDependencies": {
 		"bingo": "workspace:^",
 		"bingo-fs": "workspace:^",
 		"bingo-systems": "workspace:^",
-		"zod": "^3.24.2"
+		"zod": "^4.4.3"
 	},
 	"engines": {
 		"node": ">=18"

--- a/packages/bingo-stratum/src/creators/createStratumTemplate.ts
+++ b/packages/bingo-stratum/src/creators/createStratumTemplate.ts
@@ -1,4 +1,9 @@
-import { AnyShape, InferredObject, LazyOptionalOptions } from "bingo";
+import {
+	AnyShape,
+	InferredObject,
+	LazyOptionalOptions,
+	TemplatePrepareContext,
+} from "bingo";
 import chalk from "chalk";
 import { z } from "zod";
 
@@ -7,9 +12,11 @@ import {
 	ProduceStratumTemplateSettings,
 } from "../producers/produceStratumTemplate.js";
 import { Base } from "../types/bases.js";
+import { StratumRefinements } from "../types/refinements.js";
 import {
 	StratumTemplate,
 	StratumTemplateDefinition,
+	StratumTemplateOptionsShape,
 	ZodPresetNameLiterals,
 } from "../types/templates.js";
 import { createBlockRefinementOption } from "../utils/createBlockRefinementOption.js";
@@ -22,6 +29,9 @@ export function createStratumTemplate<OptionsShape extends AnyShape>(
 	templateDefinition: StratumTemplateDefinition<OptionsShape>,
 ): StratumTemplate<OptionsShape> {
 	type Options = InferredObject<OptionsShape>;
+	type TemplateOptions = InferredObject<
+		OptionsShape & StratumTemplateOptionsShape
+	>;
 
 	const namedBlocks = Array.from(
 		new Set(
@@ -92,19 +102,26 @@ export function createStratumTemplate<OptionsShape extends AnyShape>(
 					.sort(([a], [b]) => a.localeCompare(b)),
 			),
 		},
-		prepare(context) {
+		prepare(context): LazyOptionalOptions<Partial<TemplateOptions>> {
+			// The Template's options are the Base's options plus Stratum's own,
+			// which TypeScript can't see as a superset of the Base's alone.
+			const baseContext = context as TemplatePrepareContext<
+				Partial<Options>,
+				StratumRefinements<Options>
+			>;
 			const fromBase =
-				base.prepare?.(context) ??
+				base.prepare?.(baseContext) ??
 				// TODO: Why is this type assertion necessary?
 				// https://github.com/bingo-js/bingo/issues/287
 				({} as LazyOptionalOptions<Partial<Options>>);
 
 			// TODO: It would be better to run the base.prepare first to generate option defaults.
 			// https://github.com/bingo-js/bingo/issues/289
-			const existing = context.files && inferExistingBlocks(context, template);
+			const existing =
+				context.files && inferExistingBlocks(baseContext, template);
 
 			if (!existing) {
-				return fromBase;
+				return fromBase as LazyOptionalOptions<Partial<TemplateOptions>>;
 			}
 
 			// Enable --add-* options for any inferred existing Block not matched with an explicit --exclude-*
@@ -136,7 +153,7 @@ export function createStratumTemplate<OptionsShape extends AnyShape>(
 
 					return existing.preset;
 				},
-			};
+			} as LazyOptionalOptions<Partial<TemplateOptions>>;
 		},
 		produce(context) {
 			return produceStratumTemplate(

--- a/packages/bingo-stratum/src/creators/createStratumTemplate.ts
+++ b/packages/bingo-stratum/src/creators/createStratumTemplate.ts
@@ -16,7 +16,7 @@ import { StratumRefinements } from "../types/refinements.js";
 import {
 	StratumTemplate,
 	StratumTemplateDefinition,
-	StratumTemplateOptionsShape,
+	StratumTemplateOptionsShapeFor,
 	ZodPresetNameLiterals,
 } from "../types/templates.js";
 import { createBlockRefinementOption } from "../utils/createBlockRefinementOption.js";
@@ -30,7 +30,7 @@ export function createStratumTemplate<OptionsShape extends AnyShape>(
 ): StratumTemplate<OptionsShape> {
 	type Options = InferredObject<OptionsShape>;
 	type TemplateOptions = InferredObject<
-		OptionsShape & StratumTemplateOptionsShape
+		StratumTemplateOptionsShapeFor<OptionsShape>
 	>;
 
 	const namedBlocks = Array.from(
@@ -103,8 +103,6 @@ export function createStratumTemplate<OptionsShape extends AnyShape>(
 			),
 		},
 		prepare(context): LazyOptionalOptions<Partial<TemplateOptions>> {
-			// The Template's options are the Base's options plus Stratum's own,
-			// which TypeScript can't see as a superset of the Base's alone.
 			const baseContext = context as TemplatePrepareContext<
 				Partial<Options>,
 				StratumRefinements<Options>

--- a/packages/bingo-stratum/src/producers/produceBlock.test.ts
+++ b/packages/bingo-stratum/src/producers/produceBlock.test.ts
@@ -36,7 +36,7 @@ describe("produceBlock", () => {
 	it("passes Addons to the Block when addons is defined", () => {
 		const block = base.createBlock({
 			addons: {
-				extra: z.record(z.string()).optional(),
+				extra: z.record(z.string(), z.string()).optional(),
 			},
 			produce({ addons, options }) {
 				return {

--- a/packages/bingo-stratum/src/types/templates.ts
+++ b/packages/bingo-stratum/src/types/templates.ts
@@ -20,7 +20,7 @@ import { StratumRefinements } from "./refinements.js";
 export interface StratumTemplate<
 	OptionsShape extends AnyShape,
 > extends Template<
-	OptionsShape & StratumTemplateOptionsShape,
+	StratumTemplateOptionsShapeFor<OptionsShape>,
 	StratumRefinements<InferredObject<OptionsShape>>
 > {
 	/**
@@ -41,7 +41,7 @@ export interface StratumTemplate<
 	 * @see {@link https://www.create.bingo/build/apis/create-template#prepare}
 	 */
 	prepare: TemplatePrepare<
-		InferredObject<OptionsShape & StratumTemplateOptionsShape>,
+		InferredObject<StratumTemplateOptionsShapeFor<OptionsShape>>,
 		StratumRefinements<InferredObject<OptionsShape>>
 	>;
 
@@ -103,15 +103,21 @@ export interface StratumTemplateOptions {
 /**
  * The minimum options schemas all Stratum Templates share.
  */
-// Interfaces don't receive an implicit index signature, so intersecting one
-// with a Template's options shape stops it being assignable to AnyShape.
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-export type StratumTemplateOptionsShape = {
+export interface StratumTemplateOptionsShape {
 	/**
 	 * Union of Preset names available to choose from.
 	 */
 	preset: z.ZodDefault<z.ZodUnion<ZodPresetNameLiterals>>;
-};
+}
+
+/**
+ * Schemas of all options a Stratum Template takes in: its Base's, plus Stratum's own.
+ * @template OptionsShape Schemas of options the Base's Blocks take in.
+ */
+export type StratumTemplateOptionsShapeFor<OptionsShape extends AnyShape> =
+	OptionsShape & {
+		[Key in keyof StratumTemplateOptionsShape]: StratumTemplateOptionsShape[Key];
+	};
 
 /**
  * Union of at least two literal Preset names available to choose from.

--- a/packages/bingo-stratum/src/types/templates.ts
+++ b/packages/bingo-stratum/src/types/templates.ts
@@ -41,7 +41,7 @@ export interface StratumTemplate<
 	 * @see {@link https://www.create.bingo/build/apis/create-template#prepare}
 	 */
 	prepare: TemplatePrepare<
-		InferredObject<OptionsShape>,
+		InferredObject<OptionsShape & StratumTemplateOptionsShape>,
 		StratumRefinements<InferredObject<OptionsShape>>
 	>;
 
@@ -103,12 +103,15 @@ export interface StratumTemplateOptions {
 /**
  * The minimum options schemas all Stratum Templates share.
  */
-export interface StratumTemplateOptionsShape {
+// Interfaces don't receive an implicit index signature, so intersecting one
+// with a Template's options shape stops it being assignable to AnyShape.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export type StratumTemplateOptionsShape = {
 	/**
 	 * Union of Preset names available to choose from.
 	 */
 	preset: z.ZodDefault<z.ZodUnion<ZodPresetNameLiterals>>;
-}
+};
 
 /**
  * Union of at least two literal Preset names available to choose from.

--- a/packages/bingo-testers/package.json
+++ b/packages/bingo-testers/package.json
@@ -31,7 +31,7 @@
 		"bingo": "workspace:^",
 		"bingo-fs": "workspace:^",
 		"bingo-systems": "workspace:^",
-		"zod": "3.24.2"
+		"zod": "4.4.3"
 	},
 	"peerDependencies": {
 		"bingo": "workspace:^",

--- a/packages/bingo/package.json
+++ b/packages/bingo/package.json
@@ -40,7 +40,7 @@
 		"read-pkg": "^10.0.0",
 		"slugify": "^1.6.6",
 		"without-undefined-properties": "^0.1.2",
-		"zod": "^3.24.2"
+		"zod": "^4.4.3"
 	},
 	"devDependencies": {
 		"@types/hosted-git-info": "3.0.5",

--- a/packages/bingo/src/cli/loggers/logSchemasHelpOptions.ts
+++ b/packages/bingo/src/cli/loggers/logSchemasHelpOptions.ts
@@ -1,4 +1,5 @@
 import { AnyShape } from "../../types/shapes.js";
+import { getSchemaDescription } from "../../utils/getSchemaDescription.js";
 import { getSchemaTypeName } from "../../utils/getSchemaTypeName.js";
 import { logHelpOptions } from "./logHelpOptions.js";
 
@@ -9,7 +10,7 @@ export function logSchemasHelpOptions(packageName: string, schemas: AnyShape) {
 		Object.entries(schemas)
 			.map(([flag, schema]) => ({
 				flag: `--${flag}`,
-				text: asSentence(schema.description),
+				text: asSentence(getSchemaDescription(schema)),
 				type: getSchemaTypeName(schema),
 			}))
 			// TODO: Once a Zod-to-args conversion is made, reuse that here...

--- a/packages/bingo/src/cli/parsers/parseZodArgs.test.ts
+++ b/packages/bingo/src/cli/parsers/parseZodArgs.test.ts
@@ -51,12 +51,12 @@ describe("parseZodArgs", () => {
 
 	test("other literal parsing failure", () => {
 		const args = ["--value", "abc"];
-		const options = { value: z.literal(Symbol.for("abc")) };
+		const options = { value: z.literal(null) };
 
 		const act = () => parseZodArgs(args, options);
 
 		expect(act).toThrowError(
-			`create does not know how to parse this Zod literal on the CLI: Symbol(abc)`,
+			`create does not know how to parse this Zod literal on the CLI: null`,
 		);
 	});
 

--- a/packages/bingo/src/cli/parsers/parseZodArgs.test.ts
+++ b/packages/bingo/src/cli/parsers/parseZodArgs.test.ts
@@ -31,6 +31,15 @@ describe("parseZodArgs", () => {
 		expect(actual).toEqual({ value: "abc" });
 	});
 
+	test("default string parsing success", () => {
+		const args = ["--value", "def"];
+		const options = { value: z.string().default("abc") };
+
+		const actual = parseZodArgs(args, options);
+
+		expect(actual).toEqual({ value: "def" });
+	});
+
 	test("string parsing success", () => {
 		const args = ["--value", "abc"];
 		const options = { value: z.string() };

--- a/packages/bingo/src/cli/parsers/parseZodArgs.test.ts
+++ b/packages/bingo/src/cli/parsers/parseZodArgs.test.ts
@@ -60,6 +60,17 @@ describe("parseZodArgs", () => {
 		);
 	});
 
+	test("symbol literal parsing failure", () => {
+		const args = ["--value", "abc"];
+		const options = { value: z.literal(Symbol.for("abc") as never) };
+
+		const act = () => parseZodArgs(args, options);
+
+		expect(act).toThrowError(
+			`create does not know how to parse this Zod literal on the CLI: Symbol(abc)`,
+		);
+	});
+
 	test("object parsing failure", () => {
 		const args = ["--value"];
 		const options = { value: z.object({}) };

--- a/packages/bingo/src/cli/parsers/parseZodArgs.ts
+++ b/packages/bingo/src/cli/parsers/parseZodArgs.ts
@@ -1,18 +1,7 @@
 // TODO: Split out into standalone package
 // https://github.com/bingo-js/bingo/issues/285
-/* eslint-disable @eslint-community/eslint-comments/disable-enable-pair */
-
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/no-unsafe-argument */
-
 import { parseArgs, ParseArgsConfig } from "node:util";
-import {
-	ZodBooleanDef,
-	ZodFirstPartyTypeKind,
-	ZodLiteralDef,
-	ZodStringDef,
-	ZodTypeAny,
-} from "zod";
+import { z } from "zod";
 
 import { AnyShape, InferredObject } from "../../types/shapes.js";
 
@@ -46,48 +35,56 @@ export function parseZodArgs<OptionsShape extends AnyShape>(
 
 function zodValueToArgsOption(
 	key: string,
-	zodValue: ZodTypeAny,
+	zodValue: z.ZodType,
 ): Error | ParseArgsOptionsConfig[string] {
-	switch (zodValue._def.typeName) {
-		case "ZodBoolean":
-		case "ZodLiteral":
-		case "ZodString":
+	const def = zodValue.def;
+
+	switch (def.type) {
+		case "boolean":
+		case "literal":
+		case "string":
 			return {
-				type: zodValueTypeToArgsOptionType(zodValue._def),
+				type: zodValueTypeToArgsOptionType(def),
 			};
 
-		case "ZodDefault":
-		case "ZodOptional":
-			return zodValueToArgsOption(key, zodValue._def.innerType);
+		case "default":
+		case "optional":
+			return zodValueToArgsOption(
+				key,
+				(def as z.core.$ZodOptionalDef).innerType as z.ZodType,
+			);
 
-		case "ZodUnion":
-			return zodValueToArgsOption(key, zodValue._def.options[0]);
+		case "union":
+			return zodValueToArgsOption(
+				key,
+				(def as z.core.$ZodUnionDef).options[0] as z.ZodType,
+			);
 	}
 
 	return new Error(
-		`create does not know how to parse --${key}'s Zod type on the CLI: ${zodValue._def.typeName as string}`,
+		`create does not know how to parse --${key}'s Zod type on the CLI: ${def.type}`,
 	);
 }
 
 function zodValueTypeToArgsOptionType(
-	def: ZodBooleanDef | ZodLiteralDef | ZodStringDef,
+	def: z.core.$ZodTypeDef,
 ): ParseArgsOptionsType {
-	switch (def.typeName) {
-		case ZodFirstPartyTypeKind.ZodBoolean:
-			return "boolean";
+	if (def.type === "boolean") {
+		return "boolean";
+	}
 
-		case ZodFirstPartyTypeKind.ZodLiteral: {
-			const typeofValue = typeof def.value;
-			if (typeofValue === "boolean" || typeofValue === "string") {
-				return typeofValue;
-			}
-			throw new Error(
-				// eslint-disable-next-line @typescript-eslint/restrict-template-expressions, @typescript-eslint/no-unsafe-call
-				`create does not know how to parse this Zod literal on the CLI: ${def.value?.toString()}`,
-			);
+	if (def.type === "literal") {
+		const [value] = (def as z.core.$ZodLiteralDef<z.core.util.Literal>).values;
+		const typeofValue = typeof value;
+
+		if (typeofValue === "boolean" || typeofValue === "string") {
+			return typeofValue;
 		}
 
-		case ZodFirstPartyTypeKind.ZodString:
-			return "string";
+		throw new Error(
+			`create does not know how to parse this Zod literal on the CLI: ${String(value)}`,
+		);
 	}
+
+	return "string";
 }

--- a/packages/bingo/src/cli/prompts/promptForOptionSchema.test.ts
+++ b/packages/bingo/src/cli/prompts/promptForOptionSchema.test.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 
 import { promptForOptionSchema } from "./promptForOptionSchema.js";
 
+const mockCancel = Symbol("cancel");
 const mockConfirm = vi.fn();
 const mockSelect = vi.fn();
 const mockText = vi.fn();
@@ -11,7 +12,7 @@ vi.mock("@clack/prompts", () => ({
 	get confirm() {
 		return mockConfirm;
 	},
-	isCancel: () => false,
+	isCancel: (value: unknown) => value === mockCancel,
 	get select() {
 		return mockSelect;
 	},
@@ -102,6 +103,19 @@ describe(promptForOptionSchema, () => {
 		);
 
 		expect(actual).toBe(123);
+	});
+
+	it("returns the cancellation when the prompt is cancelled", async () => {
+		mockSelect.mockResolvedValueOnce(mockCancel);
+
+		const actual = await promptForOptionSchema(
+			"access",
+			z.enum(["public", "restricted"]),
+			undefined,
+			undefined,
+		);
+
+		expect(actual).toBe(mockCancel);
 	});
 
 	it("prompts for text when the schema is a string", async () => {

--- a/packages/bingo/src/cli/prompts/promptForOptionSchema.test.ts
+++ b/packages/bingo/src/cli/prompts/promptForOptionSchema.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+
+import { promptForOptionSchema } from "./promptForOptionSchema.js";
+
+const mockConfirm = vi.fn();
+const mockSelect = vi.fn();
+const mockText = vi.fn();
+
+vi.mock("@clack/prompts", () => ({
+	get confirm() {
+		return mockConfirm;
+	},
+	isCancel: () => false,
+	get select() {
+		return mockSelect;
+	},
+	get text() {
+		return mockText;
+	},
+}));
+
+describe(promptForOptionSchema, () => {
+	it("selects from the literals when the schema is a union of literals", async () => {
+		mockSelect.mockResolvedValueOnce("private");
+
+		const actual = await promptForOptionSchema(
+			"type",
+			z.union([z.literal("public"), z.literal("private")]),
+			"package type",
+			undefined,
+		);
+
+		expect(actual).toBe("private");
+		expect(mockSelect).toHaveBeenCalledWith({
+			initialValue: undefined,
+			message: "What will the package type be? (--type)",
+			options: [{ value: "public" }, { value: "private" }],
+		});
+	});
+
+	it("selects from the values when the schema is an enum", async () => {
+		mockSelect.mockResolvedValueOnce("restricted");
+
+		const actual = await promptForOptionSchema(
+			"access",
+			z.enum(["public", "restricted"]),
+			undefined,
+			undefined,
+		);
+
+		expect(actual).toBe("restricted");
+		expect(mockSelect).toHaveBeenCalledWith({
+			initialValue: undefined,
+			message: "What will the --access be?",
+			options: [{ value: "public" }, { value: "restricted" }],
+		});
+	});
+
+	it("prompts for the inner schema when the schema has a default", async () => {
+		mockSelect.mockResolvedValueOnce("public");
+
+		const actual = await promptForOptionSchema(
+			"type",
+			z
+				.union([z.literal("public"), z.literal("private")])
+				.describe("package type")
+				.default("public"),
+			undefined,
+			"public",
+		);
+
+		expect(actual).toBe("public");
+		expect(mockSelect).toHaveBeenCalledWith({
+			initialValue: "public",
+			message: "What will the package type be? (--type)",
+			options: [{ value: "public" }, { value: "private" }],
+		});
+	});
+
+	it("confirms when the schema is a boolean", async () => {
+		mockConfirm.mockResolvedValueOnce(true);
+
+		const actual = await promptForOptionSchema(
+			"published",
+			z.boolean(),
+			undefined,
+			false,
+		);
+
+		expect(actual).toBe(true);
+	});
+
+	it("prompts for text when the schema is a number", async () => {
+		mockText.mockResolvedValueOnce("123");
+
+		const actual = await promptForOptionSchema(
+			"count",
+			z.number(),
+			undefined,
+			undefined,
+		);
+
+		expect(actual).toBe(123);
+	});
+
+	it("prompts for text when the schema is a string", async () => {
+		mockText.mockResolvedValueOnce("My Title");
+
+		const actual = await promptForOptionSchema(
+			"title",
+			z.string(),
+			"repository title",
+			undefined,
+		);
+
+		expect(actual).toBe("My Title");
+		expect(mockText).toHaveBeenCalledWith({
+			message: "What will the repository title be? (--title)",
+			placeholder: undefined,
+			validate: expect.any(Function),
+		});
+	});
+});

--- a/packages/bingo/src/cli/prompts/promptForOptionSchema.ts
+++ b/packages/bingo/src/cli/prompts/promptForOptionSchema.ts
@@ -3,7 +3,7 @@ import * as z from "zod";
 
 import { getSchemaDescription } from "../../utils/getSchemaDescription.js";
 import { isZodDefaultDef } from "../schemas/isZodDefaultDef.js";
-import { PromptFriendlyZodDef } from "../schemas/types.js";
+import { PromptFriendlyZodDef, ZodDefType } from "../schemas/types.js";
 import { validateNumber, validatorFromSchema } from "./validators.js";
 
 export async function promptForOptionSchema(
@@ -31,7 +31,7 @@ export async function promptForOptionSchema(
 
 	while (value === undefined || value === "") {
 		switch (def.type) {
-			case "boolean": {
+			case ZodDefType.Boolean: {
 				value = await prompts.confirm({
 					initialValue: defaultValue as boolean,
 					message,
@@ -39,9 +39,7 @@ export async function promptForOptionSchema(
 				break;
 			}
 
-			case "enum": {
-				// Clack needs all option values to be the same type, which the values
-				// of any one Zod enum are in practice.
+			case ZodDefType.Enum: {
 				const options = z.core.util
 					.getEnumValues(def.entries)
 					.map((value) => ({ value })) as { value: string }[];
@@ -54,7 +52,7 @@ export async function promptForOptionSchema(
 				return cancelOrParse(schema, text);
 			}
 
-			case "number":
+			case ZodDefType.Number:
 				value = Number(
 					await prompts.text({
 						message,
@@ -64,13 +62,12 @@ export async function promptForOptionSchema(
 				);
 				break;
 
-			case "union": {
+			case ZodDefType.Union: {
 				const options = def.options.flatMap((option) =>
 					// TODO: Handle non-string-like schema data types
 					// https://github.com/bingo-js/bingo/issues/285
 					(option as z.ZodLiteral).def.values.map((value) => ({
-						// eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-						value: `${value}`,
+						value: String(value),
 					})),
 				);
 				const text = await prompts.select({

--- a/packages/bingo/src/cli/prompts/promptForOptionSchema.ts
+++ b/packages/bingo/src/cli/prompts/promptForOptionSchema.ts
@@ -1,22 +1,25 @@
 import * as prompts from "@clack/prompts";
 import * as z from "zod";
 
+import { getSchemaDescription } from "../../utils/getSchemaDescription.js";
 import { isZodDefaultDef } from "../schemas/isZodDefaultDef.js";
 import { PromptFriendlyZodDef } from "../schemas/types.js";
 import { validateNumber, validatorFromSchema } from "./validators.js";
 
 export async function promptForOptionSchema(
 	key: string,
-	schema: z.ZodTypeAny,
+	schema: z.ZodType,
 	description: string | undefined,
 	defaultValue: unknown,
 ) {
-	const def = schema._def as PromptFriendlyZodDef;
+	const def = schema.def as PromptFriendlyZodDef;
 	if (isZodDefaultDef(def)) {
+		const innerType = def.innerType as z.ZodType;
+
 		return await promptForOptionSchema(
 			key,
-			def.innerType,
-			def.innerType.description,
+			innerType,
+			getSchemaDescription(innerType),
 			defaultValue,
 		);
 	}
@@ -27,8 +30,8 @@ export async function promptForOptionSchema(
 	let value: unknown;
 
 	while (value === undefined || value === "") {
-		switch (def.typeName) {
-			case z.ZodFirstPartyTypeKind.ZodBoolean: {
+		switch (def.type) {
+			case "boolean": {
 				value = await prompts.confirm({
 					initialValue: defaultValue as boolean,
 					message,
@@ -36,8 +39,12 @@ export async function promptForOptionSchema(
 				break;
 			}
 
-			case z.ZodFirstPartyTypeKind.ZodEnum: {
-				const options = def.values.map((value) => ({ value }));
+			case "enum": {
+				// Clack needs all option values to be the same type, which the values
+				// of any one Zod enum are in practice.
+				const options = z.core.util
+					.getEnumValues(def.entries)
+					.map((value) => ({ value })) as { value: string }[];
 				const text = await prompts.select({
 					initialValue: defaultValue as string,
 					message,
@@ -47,7 +54,7 @@ export async function promptForOptionSchema(
 				return cancelOrParse(schema, text);
 			}
 
-			case z.ZodFirstPartyTypeKind.ZodNumber:
+			case "number":
 				value = Number(
 					await prompts.text({
 						message,
@@ -57,13 +64,15 @@ export async function promptForOptionSchema(
 				);
 				break;
 
-			case z.ZodFirstPartyTypeKind.ZodUnion: {
-				const options = def.options.map((option) => ({
+			case "union": {
+				const options = def.options.flatMap((option) =>
 					// TODO: Handle non-string-like schema data types
 					// https://github.com/bingo-js/bingo/issues/285
-					// eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-					value: `${(option._def as { value: number | string }).value}`,
-				}));
+					(option as z.ZodLiteral).def.values.map((value) => ({
+						// eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+						value: `${value}`,
+					})),
+				);
 				const text = await prompts.select({
 					initialValue: defaultValue as string,
 					message,
@@ -88,6 +97,6 @@ export async function promptForOptionSchema(
 	return value;
 }
 
-function cancelOrParse(schema: z.ZodTypeAny, text: unknown) {
-	return prompts.isCancel(text) ? text : (schema.parse(text) as unknown);
+function cancelOrParse(schema: z.ZodType, text: unknown) {
+	return prompts.isCancel(text) ? text : schema.parse(text);
 }

--- a/packages/bingo/src/cli/prompts/promptForOptionSchemas.test.ts
+++ b/packages/bingo/src/cli/prompts/promptForOptionSchemas.test.ts
@@ -1,0 +1,121 @@
+import { Octokit } from "octokit";
+import { describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+
+import { createTemplate } from "../../creators/createTemplate.js";
+import { SystemContext } from "../../types/system.js";
+import { promptForOptionSchemas } from "./promptForOptionSchemas.js";
+
+const mockCancel = Symbol("cancel");
+
+vi.mock("@clack/prompts", () => ({
+	isCancel: (value: unknown) => value === mockCancel,
+}));
+
+const mockPromptForOptionSchema = vi.fn();
+
+vi.mock("./promptForOptionSchema.js", () => ({
+	get promptForOptionSchema() {
+		return mockPromptForOptionSchema;
+	},
+}));
+
+const directory = "my-directory";
+
+const system: SystemContext = {
+	directory,
+	display: { item: vi.fn(), log: vi.fn() },
+	fetchers: {
+		fetch: vi.fn(),
+		octokit: {} as Octokit,
+	},
+	fs: {
+		readDirectory: vi.fn(),
+		readFile: vi.fn(),
+		writeDirectory: vi.fn(),
+		writeFile: vi.fn(),
+	},
+	runner: vi.fn(),
+};
+
+describe(promptForOptionSchemas, () => {
+	it("does not prompt when an optional option has no default", async () => {
+		const template = createTemplate({
+			options: { value: z.string().optional() },
+			produce: vi.fn(),
+		});
+
+		const actual = await promptForOptionSchemas(template, {
+			existing: {},
+			system,
+		});
+
+		expect(actual).toEqual({
+			cancelled: false,
+			completed: { directory },
+			prompted: {},
+		});
+		expect(mockPromptForOptionSchema).not.toHaveBeenCalled();
+	});
+
+	it("does not prompt when an option already has an existing value", async () => {
+		const template = createTemplate({
+			options: { value: z.string() },
+			produce: vi.fn(),
+		});
+
+		const actual = await promptForOptionSchemas(template, {
+			existing: { value: "abc" },
+			system,
+		});
+
+		expect(actual).toEqual({
+			cancelled: false,
+			completed: { directory, value: "abc" },
+			prompted: {},
+		});
+		expect(mockPromptForOptionSchema).not.toHaveBeenCalled();
+	});
+
+	it("prompts with the schema's description and default when an option is required", async () => {
+		mockPromptForOptionSchema.mockResolvedValueOnce("prompted value");
+		const template = createTemplate({
+			options: {
+				value: z.string().describe("very cool value").default("abc"),
+			},
+			produce: vi.fn(),
+		});
+
+		const actual = await promptForOptionSchemas(template, {
+			existing: {},
+			system,
+		});
+
+		expect(actual).toEqual({
+			cancelled: false,
+			completed: { directory, value: "prompted value" },
+			prompted: { value: "prompted value" },
+		});
+		expect(mockPromptForOptionSchema).toHaveBeenCalledWith(
+			"value",
+			template.options.value,
+			"very cool value",
+			"abc",
+		);
+	});
+
+	it("returns cancelled when a prompt is cancelled", async () => {
+		mockPromptForOptionSchema.mockResolvedValueOnce(mockCancel);
+		const template = createTemplate({
+			options: { value: z.string() },
+			produce: vi.fn(),
+		});
+
+		const actual = await promptForOptionSchemas(template, {
+			existing: {},
+			system,
+		});
+
+		expect(actual).toEqual({ cancelled: true, prompted: {} });
+	});
+});

--- a/packages/bingo/src/cli/prompts/promptForOptionSchemas.ts
+++ b/packages/bingo/src/cli/prompts/promptForOptionSchemas.ts
@@ -1,9 +1,11 @@
 import * as prompts from "@clack/prompts";
+import { z } from "zod";
 
 import { AnyShape, InferredObject } from "../../types/shapes.js";
 import { SystemContext } from "../../types/system.js";
 import { Template } from "../../types/templates.js";
 import { getSchemaDefaultValue } from "../../utils/getSchemaDefaultValue.js";
+import { getSchemaDescription } from "../../utils/getSchemaDescription.js";
 import { promptForOptionSchema } from "./promptForOptionSchema.js";
 
 export type PromptedOptions<Options extends object> =
@@ -45,7 +47,7 @@ export async function promptForOptionSchemas<
 	for (const [key, schema] of Object.entries(template.options)) {
 		const defaultValue = getSchemaDefaultValue(schema);
 		if (
-			(schema.isOptional() && defaultValue === undefined) ||
+			(isOptionalSchema(schema) && defaultValue === undefined) ||
 			completed[key] !== undefined
 		) {
 			continue;
@@ -54,7 +56,7 @@ export async function promptForOptionSchemas<
 		const produced = await promptForOptionSchema(
 			key,
 			schema,
-			schema.description,
+			getSchemaDescription(schema),
 			defaultValue,
 		);
 		if (prompts.isCancel(produced)) {
@@ -72,4 +74,8 @@ export async function promptForOptionSchemas<
 		} as Options,
 		prompted,
 	};
+}
+
+function isOptionalSchema(schema: z.ZodType) {
+	return schema.safeParse(undefined).success;
 }

--- a/packages/bingo/src/cli/prompts/validators.ts
+++ b/packages/bingo/src/cli/prompts/validators.ts
@@ -15,10 +15,10 @@ export function validateNumber(value: string) {
 	}
 }
 
-export function validatorFromSchema(schema: z.ZodTypeAny) {
+export function validatorFromSchema(schema: z.ZodType) {
 	return (value: string) => {
 		return (
-			schema.safeParse(value).error?.errors[0].message ?? validateText(value)
+			schema.safeParse(value).error?.issues[0].message ?? validateText(value)
 		);
 	};
 }

--- a/packages/bingo/src/cli/schemas/isStringLikeSchema.test.ts
+++ b/packages/bingo/src/cli/schemas/isStringLikeSchema.test.ts
@@ -79,7 +79,7 @@ describe("isStringLikeSchema", () => {
 		["array", z.array(z.string()), false],
 		["tuple", z.tuple([z.string()]), false],
 		["date", z.date(), false],
-		["native enum", z.nativeEnum(Value), false],
+		["native enum", z.enum(Value), true],
 	])("%s", (_, schema, expected) => {
 		expect(isStringLikeSchema(schema)).toBe(expected);
 	});

--- a/packages/bingo/src/cli/schemas/isStringLikeSchema.ts
+++ b/packages/bingo/src/cli/schemas/isStringLikeSchema.ts
@@ -1,23 +1,23 @@
 import { z } from "zod";
 
-import { PromptFriendlyZodDef } from "./types.js";
+import { PromptFriendlyZodDef, ZodDefType } from "./types.js";
 
 export function isStringLikeSchema(schema: z.ZodType): boolean {
 	const def = schema.def as PromptFriendlyZodDef;
 
 	switch (def.type) {
-		case "boolean":
-		case "enum":
-		case "literal":
-		case "number":
-		case "string":
+		case ZodDefType.Boolean:
+		case ZodDefType.Enum:
+		case ZodDefType.Literal:
+		case ZodDefType.Number:
+		case ZodDefType.String:
 			return true;
 
-		case "default":
-		case "optional":
+		case ZodDefType.Default:
+		case ZodDefType.Optional:
 			return isStringLikeSchema(def.innerType as z.ZodType);
 
-		case "union":
+		case ZodDefType.Union:
 			return def.options.every((option) =>
 				isStringLikeSchema(option as z.ZodType),
 			);

--- a/packages/bingo/src/cli/schemas/isStringLikeSchema.ts
+++ b/packages/bingo/src/cli/schemas/isStringLikeSchema.ts
@@ -2,23 +2,25 @@ import { z } from "zod";
 
 import { PromptFriendlyZodDef } from "./types.js";
 
-export function isStringLikeSchema(schema: z.ZodTypeAny): boolean {
-	const def = schema._def as PromptFriendlyZodDef;
+export function isStringLikeSchema(schema: z.ZodType): boolean {
+	const def = schema.def as PromptFriendlyZodDef;
 
-	switch (def.typeName) {
-		case z.ZodFirstPartyTypeKind.ZodBoolean:
-		case z.ZodFirstPartyTypeKind.ZodEnum:
-		case z.ZodFirstPartyTypeKind.ZodLiteral:
-		case z.ZodFirstPartyTypeKind.ZodNumber:
-		case z.ZodFirstPartyTypeKind.ZodString:
+	switch (def.type) {
+		case "boolean":
+		case "enum":
+		case "literal":
+		case "number":
+		case "string":
 			return true;
 
-		case z.ZodFirstPartyTypeKind.ZodDefault:
-		case z.ZodFirstPartyTypeKind.ZodOptional:
-			return isStringLikeSchema(def.innerType);
+		case "default":
+		case "optional":
+			return isStringLikeSchema(def.innerType as z.ZodType);
 
-		case z.ZodFirstPartyTypeKind.ZodUnion:
-			return def.options.every((option) => isStringLikeSchema(option));
+		case "union":
+			return def.options.every((option) =>
+				isStringLikeSchema(option as z.ZodType),
+			);
 
 		default:
 			return false;

--- a/packages/bingo/src/cli/schemas/isZodDefaultDef.test.ts
+++ b/packages/bingo/src/cli/schemas/isZodDefaultDef.test.ts
@@ -33,9 +33,9 @@ describe("isZodDefaultDef", () => {
 		["default tuple", z.tuple([z.string()]).default([""]), true],
 		["date", z.date(), false],
 		["default date", z.date().default(new Date()), true],
-		["native enum", z.nativeEnum(Value), false],
-		["default native enum", z.nativeEnum(Value).default(Value.A), true],
+		["native enum", z.enum(Value), false],
+		["default native enum", z.enum(Value).default(Value.A), true],
 	])("%s", (_, schema, expected) => {
-		expect(isZodDefaultDef(schema._def)).toBe(expected);
+		expect(isZodDefaultDef(schema.def)).toBe(expected);
 	});
 });

--- a/packages/bingo/src/cli/schemas/isZodDefaultDef.ts
+++ b/packages/bingo/src/cli/schemas/isZodDefaultDef.ts
@@ -1,9 +1,7 @@
-// eslint-disable-next-line @eslint-community/eslint-comments/disable-enable-pair
-/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access */
 import { z } from "zod";
 
-import { ZodDefaultDefWithType } from "./types.js";
-
-export function isZodDefaultDef(def: any): def is ZodDefaultDefWithType {
-	return def.typeName === z.ZodFirstPartyTypeKind.ZodDefault;
+export function isZodDefaultDef(
+	def: z.core.$ZodTypeDef,
+): def is z.core.$ZodDefaultDef {
+	return def.type === "default";
 }

--- a/packages/bingo/src/cli/schemas/types.ts
+++ b/packages/bingo/src/cli/schemas/types.ts
@@ -1,14 +1,35 @@
 import { z } from "zod";
 
 /**
+ * The `def.type` values of the Zod schemas we know how to prompt for.
+ */
+export enum ZodDefType {
+	Boolean = "boolean",
+	Default = "default",
+	Enum = "enum",
+	Literal = "literal",
+	Number = "number",
+	Optional = "optional",
+	String = "string",
+	Union = "union",
+}
+
+type WithZodDefType<Def, Type extends ZodDefType> = Omit<Def, "type"> & {
+	type: Type;
+};
+
+/**
  * The known Zod schema definitions that we know how to prompt for with Clack.
  */
 export type PromptFriendlyZodDef =
-	| z.core.$ZodBooleanDef
-	| z.core.$ZodDefaultDef
-	| z.core.$ZodEnumDef
-	| z.core.$ZodLiteralDef<z.core.util.Literal>
-	| z.core.$ZodNumberDef
-	| z.core.$ZodOptionalDef
-	| z.core.$ZodStringDef
-	| z.core.$ZodUnionDef;
+	| WithZodDefType<z.core.$ZodBooleanDef, ZodDefType.Boolean>
+	| WithZodDefType<z.core.$ZodDefaultDef, ZodDefType.Default>
+	| WithZodDefType<z.core.$ZodEnumDef, ZodDefType.Enum>
+	| WithZodDefType<
+			z.core.$ZodLiteralDef<z.core.util.Literal>,
+			ZodDefType.Literal
+	  >
+	| WithZodDefType<z.core.$ZodNumberDef, ZodDefType.Number>
+	| WithZodDefType<z.core.$ZodOptionalDef, ZodDefType.Optional>
+	| WithZodDefType<z.core.$ZodStringDef, ZodDefType.String>
+	| WithZodDefType<z.core.$ZodUnionDef, ZodDefType.Union>;

--- a/packages/bingo/src/cli/schemas/types.ts
+++ b/packages/bingo/src/cli/schemas/types.ts
@@ -1,22 +1,14 @@
 import { z } from "zod";
 
 /**
- * The known Zod schema types that we know how to prompt for with Clack.
+ * The known Zod schema definitions that we know how to prompt for with Clack.
  */
 export type PromptFriendlyZodDef =
-	| z.ZodBooleanDef
-	| z.ZodEnumDef
-	| z.ZodLiteralDef
-	| z.ZodNumberDef
-	| z.ZodOptionalDef
-	| z.ZodStringDef
-	| z.ZodUnionDef
-	| ZodDefaultDefWithType;
-
-/**
- * Our view of default defs: we access the private innerType and typeName properties.
- */
-export type ZodDefaultDefWithType = z.ZodDefaultDef & {
-	innerType: z.ZodTypeAny;
-	typeName: z.ZodFirstPartyTypeKind.ZodDefault;
-};
+	| z.core.$ZodBooleanDef
+	| z.core.$ZodDefaultDef
+	| z.core.$ZodEnumDef
+	| z.core.$ZodLiteralDef<z.core.util.Literal>
+	| z.core.$ZodNumberDef
+	| z.core.$ZodOptionalDef
+	| z.core.$ZodStringDef
+	| z.core.$ZodUnionDef;

--- a/packages/bingo/src/preparation/prepareOptions.ts
+++ b/packages/bingo/src/preparation/prepareOptions.ts
@@ -56,7 +56,9 @@ export async function prepareOptions<OptionsShape extends AnyShape>(
 			exclude: /node_modules|^\.git$/,
 		})) as CreatedDirectory);
 
-	return await allPropertiesLazy({
+	// Zod infers option values through a conditional type, which TypeScript
+	// can't relate to the lazily awaited properties of the same options.
+	return (await allPropertiesLazy({
 		...base.prepare({
 			files,
 			log: system.display.log,
@@ -64,5 +66,5 @@ export async function prepareOptions<OptionsShape extends AnyShape>(
 			...system,
 		}),
 		...existing,
-	});
+	})) as Partial<InferredObject<OptionsShape>>;
 }

--- a/packages/bingo/src/preparation/prepareOptions.ts
+++ b/packages/bingo/src/preparation/prepareOptions.ts
@@ -56,8 +56,6 @@ export async function prepareOptions<OptionsShape extends AnyShape>(
 			exclude: /node_modules|^\.git$/,
 		})) as CreatedDirectory);
 
-	// Zod infers option values through a conditional type, which TypeScript
-	// can't relate to the lazily awaited properties of the same options.
 	return (await allPropertiesLazy({
 		...base.prepare({
 			files,

--- a/packages/bingo/src/types/shapes.ts
+++ b/packages/bingo/src/types/shapes.ts
@@ -27,9 +27,7 @@ export type AnyShape = Record<string, z.ZodType>;
  */
 export type InferredObject<OptionsShape extends AnyShape | undefined> =
 	OptionsShape extends AnyShape
-		? // Zod infers an object schema with no properties as Record<string, never>,
-			// which can't be intersected with any other properties.
-			keyof OptionsShape extends never
+		? keyof OptionsShape extends never
 			? object
 			: z.infer<z.ZodObject<OptionsShape>>
 		: undefined;

--- a/packages/bingo/src/types/shapes.ts
+++ b/packages/bingo/src/types/shapes.ts
@@ -12,7 +12,7 @@ export type AnyOptionalShape = Record<
 /**
  * Any object containing Zod schemas as values.
  */
-export type AnyShape = z.ZodRawShape;
+export type AnyShape = Record<string, z.ZodType>;
 
 /**
  * Given an object containing Zod schemas, produces the equivalent runtime type.
@@ -27,5 +27,9 @@ export type AnyShape = z.ZodRawShape;
  */
 export type InferredObject<OptionsShape extends AnyShape | undefined> =
 	OptionsShape extends AnyShape
-		? z.infer<z.ZodObject<OptionsShape>>
+		? // Zod infers an object schema with no properties as Record<string, never>,
+			// which can't be intersected with any other properties.
+			keyof OptionsShape extends never
+			? object
+			: z.infer<z.ZodObject<OptionsShape>>
 		: undefined;

--- a/packages/bingo/src/types/templates.ts
+++ b/packages/bingo/src/types/templates.ts
@@ -1,5 +1,4 @@
 import { CreatedDirectory } from "bingo-fs";
-import { ZodRawShape } from "zod";
 
 import { AboutBase } from "./about.js";
 import { CreateTemplateConfig } from "./configs.js";
@@ -40,7 +39,7 @@ export interface RepositoryLocator {
  * @see {@link https://create.bingo/build/concepts/templates}
  */
 export interface Template<
-	OptionsShape extends AnyShape = ZodRawShape,
+	OptionsShape extends AnyShape = AnyShape,
 	Refinements = unknown,
 > extends TemplateDefinition<OptionsShape, Refinements> {
 	/**

--- a/packages/bingo/src/utils/getSchemaDefaultValue.test.ts
+++ b/packages/bingo/src/utils/getSchemaDefaultValue.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { getSchemaDefaultValue } from "./getSchemaDefaultValue.js";
+
+describe(getSchemaDefaultValue, () => {
+	it("returns undefined when the schema has no default", () => {
+		const actual = getSchemaDefaultValue(z.string());
+
+		expect(actual).toBeUndefined();
+	});
+
+	it("returns the default value when the schema has one", () => {
+		const actual = getSchemaDefaultValue(z.string().default("abc"));
+
+		expect(actual).toBe("abc");
+	});
+
+	it("returns the resolved value when the schema has a lazy default", () => {
+		const actual = getSchemaDefaultValue(z.string().default(() => "abc"));
+
+		expect(actual).toBe("abc");
+	});
+});

--- a/packages/bingo/src/utils/getSchemaDefaultValue.ts
+++ b/packages/bingo/src/utils/getSchemaDefaultValue.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
 
-export function getSchemaDefaultValue(schema: z.ZodTypeAny) {
-	return (schema._def as Partial<z.ZodDefaultDef>).defaultValue?.() as unknown;
+export function getSchemaDefaultValue(schema: z.ZodType) {
+	return (schema.def as Partial<z.core.$ZodDefaultDef>).defaultValue;
 }

--- a/packages/bingo/src/utils/getSchemaDescription.test.ts
+++ b/packages/bingo/src/utils/getSchemaDescription.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { getSchemaDescription } from "./getSchemaDescription.js";
+
+describe(getSchemaDescription, () => {
+	it("returns undefined when the schema has no description", () => {
+		const actual = getSchemaDescription(z.string());
+
+		expect(actual).toBeUndefined();
+	});
+
+	it("returns the description when the schema is described", () => {
+		const actual = getSchemaDescription(z.string().describe("abc"));
+
+		expect(actual).toBe("abc");
+	});
+
+	it("returns the inner description when the described schema has a default", () => {
+		const actual = getSchemaDescription(z.string().describe("abc").default(""));
+
+		expect(actual).toBe("abc");
+	});
+
+	it("returns the inner description when the described schema is optional", () => {
+		const actual = getSchemaDescription(z.string().describe("abc").optional());
+
+		expect(actual).toBe("abc");
+	});
+
+	it("returns the outer description when both the schema and its inner schema are described", () => {
+		const actual = getSchemaDescription(
+			z.string().describe("inner").default("").describe("outer"),
+		);
+
+		expect(actual).toBe("outer");
+	});
+});

--- a/packages/bingo/src/utils/getSchemaDescription.ts
+++ b/packages/bingo/src/utils/getSchemaDescription.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+import { getSchemaInner } from "./getSchemaInner.js";
+
+export function getSchemaDescription(schema: z.ZodType) {
+	// Zod stores descriptions per schema, so wrappers such as .default() don't
+	// have the description of the schema they wrap.
+	return schema.description ?? getSchemaInner(schema).description;
+}

--- a/packages/bingo/src/utils/getSchemaDescription.ts
+++ b/packages/bingo/src/utils/getSchemaDescription.ts
@@ -3,7 +3,5 @@ import { z } from "zod";
 import { getSchemaInner } from "./getSchemaInner.js";
 
 export function getSchemaDescription(schema: z.ZodType) {
-	// Zod stores descriptions per schema, so wrappers such as .default() don't
-	// have the description of the schema they wrap.
 	return schema.description ?? getSchemaInner(schema).description;
 }

--- a/packages/bingo/src/utils/getSchemaInner.ts
+++ b/packages/bingo/src/utils/getSchemaInner.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+
+/**
+ * Unwraps any schema wrappers, such as defaults and optionals, from a schema.
+ */
+export function getSchemaInner(schema: z.ZodType): z.ZodType {
+	const def = schema.def;
+
+	switch (def.type) {
+		case "default":
+		case "nullable":
+		case "optional":
+			return getSchemaInner(
+				(def as z.core.$ZodOptionalDef).innerType as z.ZodType,
+			);
+
+		case "pipe":
+			return getSchemaInner((def as z.core.$ZodPipeDef).in as z.ZodType);
+
+		default:
+			return schema;
+	}
+}

--- a/packages/bingo/src/utils/getSchemaTypeName.test.ts
+++ b/packages/bingo/src/utils/getSchemaTypeName.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "vitest";
+import { z } from "zod";
+
+import { getSchemaTypeName } from "./getSchemaTypeName.js";
+
+describe("getSchemaTypeName", () => {
+	test.each([
+		["string", z.string(), "string"],
+		["number", z.number(), "number"],
+		["boolean", z.boolean(), "boolean"],
+		["object", z.object({}), "object"],
+		["record", z.record(z.string(), z.string()), "record"],
+		["optional string", z.string().optional(), "string"],
+		["default string", z.string().default("abc"), "string"],
+		["nullable string", z.string().nullable(), "string"],
+		[
+			"transformed string",
+			z.string().transform((value) => value.length),
+			"string",
+		],
+		["array of strings", z.array(z.string()), "string[]"],
+		["array of arrays of numbers", z.array(z.array(z.number())), "number[][]"],
+		["string literal", z.literal("abc"), `"abc"`],
+		["number literal", z.literal(123), "123"],
+		["multiple literal values", z.literal(["abc", "def"]), `"abc" | "def"`],
+		[
+			"union of literals",
+			z.union([z.literal("abc"), z.literal("def")]),
+			`"abc" | "def"`,
+		],
+		[
+			"union including an object",
+			z.union([z.literal("abc"), z.object({})]),
+			`"abc"`,
+		],
+	])("%s", (_, schema, expected) => {
+		expect(getSchemaTypeName(schema)).toBe(expected);
+	});
+});

--- a/packages/bingo/src/utils/getSchemaTypeName.ts
+++ b/packages/bingo/src/utils/getSchemaTypeName.ts
@@ -1,47 +1,33 @@
 // TODO: Split Zod generation out into standalone package
 // https://github.com/bingo-js/bingo/issues/285
-/* eslint-disable @eslint-community/eslint-comments/disable-enable-pair */
-
-/* eslint-disable @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access */
-
 import { z } from "zod";
 
-export function getSchemaTypeName(schema: z.ZodTypeAny): string {
+import { getSchemaInner } from "./getSchemaInner.js";
+
+export function getSchemaTypeName(schema: z.ZodType): string {
 	const schemaInner = getSchemaInner(schema);
+	const def = schemaInner.def;
 
-	if (schemaInner._def.typeName === z.ZodFirstPartyTypeKind.ZodArray) {
-		return `${getSchemaTypeName(schemaInner._def.type)}[]`;
+	switch (def.type) {
+		case "array":
+			return `${getSchemaTypeName((def as z.core.$ZodArrayDef).element as z.ZodType)}[]`;
+
+		case "literal":
+			return (def as z.core.$ZodLiteralDef<z.core.util.Literal>).values
+				.map((value) => JSON.stringify(value))
+				.join(" | ");
+
+		case "union":
+			return (
+				(def as z.core.$ZodUnionDef).options
+					.map((constituent) => getSchemaTypeName(constituent as z.ZodType))
+					// TODO: Once these can be parsed as args, reuse that here...
+					// https://github.com/bingo-js/bingo/issues/285
+					.filter((typeName) => !["object", "record"].includes(typeName))
+					.join(" | ")
+			);
+
+		default:
+			return def.type;
 	}
-
-	if (schemaInner._def.typeName === z.ZodFirstPartyTypeKind.ZodLiteral) {
-		return JSON.stringify((schemaInner._def as z.ZodLiteralDef).value);
-	}
-
-	if (schemaInner._def.typeName === z.ZodFirstPartyTypeKind.ZodUnion) {
-		return (
-			(schemaInner._def as z.ZodUnionDef).options
-				.map((constituent) => getSchemaTypeName(constituent))
-				// TODO: Once these can be parsed as args, reuse that here...
-				// https://github.com/bingo-js/bingo/issues/285
-				.filter((typeName) => !["object", "record"].includes(typeName))
-				.join(" | ")
-		);
-	}
-
-	// n.b. it's not necessary an object, that's just one of many with a typeName
-	return (schemaInner._def as z.ZodObjectDef).typeName
-		.replace("Zod", "")
-		.toLowerCase();
-}
-
-function getSchemaInner(schema: z.ZodTypeAny): z.ZodTypeAny {
-	if (schema.isOptional()) {
-		return getSchemaInner((schema._def as z.ZodOptionalDef).innerType);
-	}
-
-	if (schema._def.typeName === z.ZodFirstPartyTypeKind.ZodEffects) {
-		return getSchemaInner((schema._def as z.ZodEffectsDef).schema);
-	}
-
-	return schema;
 }

--- a/packages/input-from-fetch/package.json
+++ b/packages/input-from-fetch/package.json
@@ -22,7 +22,7 @@
 		"build": "tsc"
 	},
 	"dependencies": {
-		"zod": "^3.24.2"
+		"zod": "^4.4.3"
 	},
 	"devDependencies": {
 		"bingo": "workspace:^",

--- a/packages/input-from-file/package.json
+++ b/packages/input-from-file/package.json
@@ -22,7 +22,7 @@
 		"build": "tsc"
 	},
 	"dependencies": {
-		"zod": "^3.24.2"
+		"zod": "^4.4.3"
 	},
 	"devDependencies": {
 		"bingo": "workspace:^",

--- a/packages/input-from-script/package.json
+++ b/packages/input-from-script/package.json
@@ -22,7 +22,7 @@
 		"build": "tsc"
 	},
 	"dependencies": {
-		"zod": "^3.24.2"
+		"zod": "^4.4.3"
 	},
 	"devDependencies": {
 		"bingo": "workspace:^",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,8 +156,8 @@ importers:
         specifier: ^0.1.2
         version: 0.1.2
       zod:
-        specifier: ^3.24.2
-        version: 3.24.2
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@types/hosted-git-info':
         specifier: 3.0.5
@@ -228,8 +228,8 @@ importers:
         specifier: workspace:^
         version: link:../bingo-systems
       zod:
-        specifier: ^3.24.2
-        version: 3.24.2
+        specifier: ^4.4.3
+        version: 4.4.3
 
   packages/bingo-stratum-testers:
     devDependencies:
@@ -246,8 +246,8 @@ importers:
         specifier: workspace:^
         version: link:../bingo-systems
       zod:
-        specifier: 3.24.2
-        version: 3.24.2
+        specifier: 4.4.3
+        version: 4.4.3
 
   packages/bingo-systems:
     dependencies:
@@ -293,8 +293,8 @@ importers:
         specifier: workspace:^
         version: link:../bingo-systems
       zod:
-        specifier: 3.24.2
-        version: 3.24.2
+        specifier: 4.4.3
+        version: 4.4.3
 
   packages/create:
     dependencies:
@@ -305,8 +305,8 @@ importers:
   packages/input-from-fetch:
     dependencies:
       zod:
-        specifier: ^3.24.2
-        version: 3.24.2
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       bingo:
         specifier: workspace:^
@@ -318,8 +318,8 @@ importers:
   packages/input-from-file:
     dependencies:
       zod:
-        specifier: ^3.24.2
-        version: 3.24.2
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       bingo:
         specifier: workspace:^
@@ -344,8 +344,8 @@ importers:
   packages/input-from-script:
     dependencies:
       zod:
-        specifier: ^3.24.2
-        version: 3.24.2
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       bingo:
         specifier: workspace:^
@@ -1029,89 +1029,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1327,41 +1343,49 @@ packages:
     resolution: {integrity: sha512-O8iTBqz6oxf1k93Rn6WMGGQYo2jV1K81hq4N/Nke3dHE25EIEg2RKQqMz1dFrvVb2RkvD7QaUTEevbx0Lq+4wQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-arm64-musl@11.14.2':
     resolution: {integrity: sha512-HOfzpS6eUxvdch9UlXCMx2kNJWMNBjUpVJhseqAKDB1dlrfCHgexeLyBX977GLXkq2BtNXKsY3KCryy1QhRSRw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-ppc64-gnu@11.14.2':
     resolution: {integrity: sha512-0uLG6F2zljUseQAUmlpx/9IdKpiLsSirpmrr8/aGVfiEurIJzC/1lo2HQskkM7e0VVOkXg37AjHUDLE23Fi8SA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-gnu@11.14.2':
     resolution: {integrity: sha512-Pdh0BH/E0YIK7Qg95IsAfQyU9rAoDoFh50R19zCTNfjSnwsoDMGHjmUc82udSfPo2YMnuxA+/+aglxmLQVSu2Q==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-musl@11.14.2':
     resolution: {integrity: sha512-3DLQhJ2r53rCH5cudYFqD7nh+Z6ABvld3GjbiqHhT43GMIPw3JcHekC2QunLRNjRr1G544fo1HtjTJz9rCBpyg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-s390x-gnu@11.14.2':
     resolution: {integrity: sha512-G5BnAOQ5f+RUG1cvlJ4BvV+P7iKLYBv67snqgcfwD5b2N4UwJj32bt4H5JfolocWy4x3qUjEDWTIjHdE+2uZ9w==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-gnu@11.14.2':
     resolution: {integrity: sha512-VirQAX2PqKrhWtQGsSDEKlPhbgh3ggjT1sWuxLk4iLFwtyA2tLEPXJNAsG0kfAS2+VSA8OyNq16wRpQlMPZ4yA==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-musl@11.14.2':
     resolution: {integrity: sha512-q4ORcwMkpzu4EhZyka/s2TuH2QklEHAr/mIQBXzu5BACeBJZIFkICp8qrq4XVnkEZ+XhSFTvBECqfMTT/4LSkA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-openharmony-arm64@11.14.2':
     resolution: {integrity: sha512-ZsMIpDCxSFpUM/TwOovX5vZUkV0IukPFnrKTGaeJRuTKXMcJxMiQGCYTwd6y684Y3j55QZqIMkVM9NdCGUX6Kw==}
@@ -1467,56 +1491,67 @@ packages:
     resolution: {integrity: sha512-k9oD15soC/Ln6d2Wv/JOFPzZXIAIFLp6B+i14KhxAfnq76ajt0EhYc5YPeX6W1xJkAdItcVT+JhKl1QZh44/qw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.53.3':
     resolution: {integrity: sha512-vTNlKq+N6CK/8UktsrFuc+/7NlEYVxgaEgRXVUVK258Z5ymho29skzW1sutgYjqNnquGwVUObAaxae8rZ6YMhg==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.53.3':
     resolution: {integrity: sha512-RGrFLWgMhSxRs/EWJMIFM1O5Mzuz3Xy3/mnxJp/5cVhZ2XoCAxJnmNsEyeMJtpK+wu0FJFWz+QF4mjCA7AUQ3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.53.3':
     resolution: {integrity: sha512-kASyvfBEWYPEwe0Qv4nfu6pNkITLTb32p4yTgzFCocHnJLAHs+9LjUu9ONIhvfT/5lv4YS5muBHyuV84epBo/A==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.53.3':
     resolution: {integrity: sha512-JiuKcp2teLJwQ7vkJ95EwESWkNRFJD7TQgYmCnrPtlu50b4XvT5MOmurWNrCj3IFdyjBQ5p9vnrX4JM6I8OE7g==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.53.3':
     resolution: {integrity: sha512-EoGSa8nd6d3T7zLuqdojxC20oBfNT8nexBbB/rkxgKj5T5vhpAQKKnD+h3UkoMuTyXkP5jTjK/ccNRmQrPNDuw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.53.3':
     resolution: {integrity: sha512-4s+Wped2IHXHPnAEbIB0YWBv7SDohqxobiiPA1FIWZpX+w9o2i4LezzH/NkFUl8LRci/8udci6cLq+jJQlh+0g==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.53.3':
     resolution: {integrity: sha512-68k2g7+0vs2u9CxDt5ktXTngsxOQkSEV/xBbwlqYcUrAVh6P9EgMZvFsnHy4SEiUl46Xf0IObWVbMvPrr2gw8A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.53.3':
     resolution: {integrity: sha512-VYsFMpULAz87ZW6BVYw3I6sWesGpsP9OPcyKe8ofdg9LHxSbRMd7zrVrr5xi/3kMZtpWL/wC+UIJWJYVX5uTKg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.53.3':
     resolution: {integrity: sha512-3EhFi1FU6YL8HTUJZ51imGJWEX//ajQPfqWLI3BQq4TlvHy4X0MOr5q3D2Zof/ka0d5FNdPwZXm3Yyib/UEd+w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.53.3':
     resolution: {integrity: sha512-eoROhjcc6HbZCJr+tvVT8X4fW3/5g/WkGvvmwz/88sDtSJzO7r/blvoBDgISDiCjDRZmHpwud7h+6Q9JxFwq1Q==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.53.3':
     resolution: {integrity: sha512-OueLAWgrNSPGAdUdIjSWXw+u/02BRTcnfw9PN41D2vq/JSEPnJnVuBgw18VkN8wcd4fjUs+jFHVM4t9+kBSNLw==}
@@ -1730,6 +1765,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vitest/coverage-v8@4.0.15':
     resolution: {integrity: sha512-FUJ+1RkpTFW7rQITdgTi93qOCWJobWhBirEPCeXh2SW2wsTlFxy51apDz5gzG+ZEYt/THvWeNmhdAoS9DTwpCw==}
@@ -2371,6 +2407,7 @@ packages:
   eslint-plugin-markdown@5.1.0:
     resolution: {integrity: sha512-SJeyKko1K6GwI0AN6xeCDToXDkfKZfXcexA6B+O2Wr2btUS9GrC+YgwSyVli5DJnctUHjFXcQ2cqTaAmVoLi2A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: Please use @eslint/markdown instead
     peerDependencies:
       eslint: '>=8'
 
@@ -4001,6 +4038,7 @@ packages:
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
     engines: {node: ^18 || >=20}
+    deprecated: unmaintained
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0
@@ -4536,14 +4574,11 @@ packages:
       typescript: ^4.9.4 || ^5.0.2
       zod: ^3
 
-  zod@3.24.2:
-    resolution: {integrity: sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==}
-
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
-  zod@4.1.13:
-    resolution: {integrity: sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==}
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -7420,7 +7455,7 @@ snapshots:
       smol-toml: 1.5.2
       strip-json-comments: 5.0.3
       typescript: 5.9.3
-      zod: 4.1.13
+      zod: 4.4.3
 
   konami-code-js@0.8.3: {}
 
@@ -9434,10 +9469,8 @@ snapshots:
       typescript: 5.9.3
       zod: 3.25.76
 
-  zod@3.24.2: {}
-
   zod@3.25.76: {}
 
-  zod@4.1.13: {}
+  zod@4.4.3: {}
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #399
- [x] That issue was marked as [`status: accepting prs`](https://github.com/bingo-js/bingo/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/bingo-js/bingo/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Moves every package to `zod@^4`. The reported union bug was one of four separate v4 incompatibilities, all fixed here:

1. **Schema type discrimination.** v4 replaced `_def.typeName` with a public `type` discriminant, and `ZodFirstPartyTypeKind` is now an empty stub enum. `isStringLikeSchema`, `isZodDefaultDef`, `promptForOptionSchema`, `parseZodArgs`, and `getSchemaTypeName` now switch on `def.type` (`"union"`, `"default"`, …). This is what made `z.union([z.literal("public"), z.literal("private")])` fall through to a text prompt.
2. **Defaults.** `$ZodDefaultDef["defaultValue"]` is a value (or getter), not a function.
3. **Errors.** `ZodError.errors` is gone; `validatorFromSchema` reads `issues` so schema validation messages reach prompts again.
4. **Deprecations.** `_def` → `def`, `ZodTypeAny` → `ZodType`, `isOptional()` → an explicit `safeParse(undefined)` check, and `z.nativeEnum` → `z.enum`.

### Notable knock-on changes

- `AnyShape` is `Record<string, z.ZodType>` rather than `z.ZodRawShape`, which in v4 is the *core* `$ZodShape` and so lacks `.parse`, `.description`, and friends.
- `InferredObject<{}>` special-cases empty shapes: v4 infers an empty object schema as `Record<string, never>`, which can't be intersected with anything, so a Stratum base with no options couldn't be produced.
- Descriptions are stored per schema instance in v4, so `z.string().describe("…").default("…")` loses its description on the wrapper. A new `getSchemaDescription` unwraps to find it, restoring v3's `--help` output.
- `z.enum(SomeNativeEnum)` is now prompted as an enum (v4 merged `nativeEnum` into `enum`), using `z.core.util.getEnumValues` so numeric enums don't pick up their reverse mappings.
- v4 infers object output through a *conditional* type, which TypeScript can't relate across generic shapes the way v3's mapped types could. Three internal assertions in `prepareOptions` and `createStratumTemplate` cover that; no user-facing type changed.
- Includes the one-line `StratumTemplateOptionsShape` interface → type alias from #272 / #403, because v4 turns that latent inference failure into a hard build error here. If #403 lands first this rebases cleanly.

Templates will need to be on zod v4 after this, and consumers such as create-typescript-app are intentionally left for separate follow-ups.

💝