### PR TITLE
chore: bring in newly exported node:util parseArgs types

### DIFF
--- a/packages/bingo/src/cli/cliArgsOptions.ts
+++ b/packages/bingo/src/cli/cliArgsOptions.ts
@@ -1,9 +1,4 @@
-import { ParseArgsConfig } from "node:util";
-
-// TODO: Send issue/PR to DefinitelyTyped to export these from node:util...
-// https://github.com/bingo-js/bingo/issues/284
-
-type ParseArgsOptionsConfig = NonNullable<ParseArgsConfig["options"]>;
+import { ParseArgsOptionsConfig } from "node:util";
 
 export const cliArgsOptions = {
 	directory: {

--- a/packages/bingo/src/cli/parsers/parseZodArgs.ts
+++ b/packages/bingo/src/cli/parsers/parseZodArgs.ts
@@ -1,22 +1,20 @@
 // TODO: Split out into standalone package
 // https://github.com/bingo-js/bingo/issues/285
-import { parseArgs, ParseArgsConfig } from "node:util";
+import {
+	parseArgs,
+	ParseArgsOptionDescriptor,
+	ParseArgsOptionsConfig,
+	ParseArgsOptionsType,
+} from "node:util";
 import { z } from "zod";
 
 import { AnyShape, InferredObject } from "../../types/shapes.js";
-
-// TODO: Send issue/PR to DefinitelyTyped to export these from node:util...
-// https://github.com/bingo-js/bingo/issues/284
-
-type ParseArgsOptionsConfig = NonNullable<ParseArgsConfig["options"]>;
-
-type ParseArgsOptionsType = ParseArgsOptionsConfig[string]["type"];
 
 export function parseZodArgs<OptionsShape extends AnyShape>(
 	args: string[],
 	options: OptionsShape,
 ): InferredObject<OptionsShape> {
-	const argsOptions: ParseArgsConfig["options"] = {};
+	const argsOptions: ParseArgsOptionsConfig = {};
 
 	for (const [key, value] of Object.entries(options)) {
 		const argsOption = zodValueToArgsOption(key, value);
@@ -36,7 +34,7 @@ export function parseZodArgs<OptionsShape extends AnyShape>(
 function zodValueToArgsOption(
 	key: string,
 	zodValue: z.ZodType,
-): Error | ParseArgsOptionsConfig[string] {
+): Error | ParseArgsOptionDescriptor {
 	const def = zodValue.def;
 
 	switch (def.type) {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #284
- [x] That issue was marked as [`status: accepting prs`](https://github.com/bingo-js/bingo/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/bingo-js/bingo/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

`@types/node` now exports `ParseArgsOptionsConfig`, `ParseArgsOptionDescriptor`, and `ParseArgsOptionsType` from `node:util`, so the local aliases that reached into `ParseArgsConfig["options"]` are no longer needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

💝 